### PR TITLE
feat(skills): flesh out Python content in dependabot-triage-py

### DIFF
--- a/skills/_shared/fragments/prioritization-framework.md
+++ b/skills/_shared/fragments/prioritization-framework.md
@@ -4,3 +4,5 @@ Three axes, in order:
 1. **Impact** — RCE > data exfil/SSRF > DoS > logic bugs
 2. **Exposure** — see Exposure Mapping below. NOT a heuristic guess about whether the vuln is reachable. A categorization of where the package is imported, presented to the user as a surface-area summary.
 3. **CVSS** — tiebreaker only. Raw score without exposure context misleads (e.g. SSRF in axios shows 4.8 but matters more if axios is in Public/API).
+
+> **CVSS=0 fallback.** Dependabot returns `security_advisory.cvss.score: 0` (or `null`) when the advisory hasn't been scored yet — common for fresh GHSAs. Don't let an unscored alert sink to the bottom of a CVSS-sorted ranking; fall back to `security_advisory.severity` (always populated). Approximate score mapping: `critical` ≈ 9.5, `high` ≈ 7.5, `medium` ≈ 5.0, `low` ≈ 2.0. Surface the fallback explicitly in the ranked table — e.g. `cvss: — (high)` rather than `cvss: 0` — so the user understands why a high-severity alert sits above a low-CVSS one.

--- a/skills/dependabot-triage-py/README.md
+++ b/skills/dependabot-triage-py/README.md
@@ -1,8 +1,8 @@
-# dependabot-triage-py (v2.1 — scaffold)
+# dependabot-triage-py (v2.1)
 
 [![skills.sh](https://skills.sh/akshayrao14/dependabot-triage-py)](https://skills.sh/akshayrao14/dependabot-triage-py)
 
-> **Scaffold — not yet feature-complete.** The shared workflow (fetch + rank + mode selection + branching + parity-check framework + commit/PR + after-merge) is wired in. Python-specific blocks (PM detection, override pattern, exposure categories, version syntax, parity-check commands, platform notes) are stubbed with `<!-- TODO(py): ... -->` markers in `SKILL.md` and will be fleshed out in a follow-up. Some shared examples reference JS packages (axios, dompurify) — those are illustrative; the concepts apply to Python ecosystems. For the production-ready JS sibling, see [dependabot-triage](https://github.com/akshayrao14/dependabot-triage).
+> **Note:** Python-specific workflow content (PM detection, override pattern, exposure categories, PEP 440 version syntax, per-PM parity-check commands, native-wheel platform notes) is fleshed out. A small number of examples in the shared-fragment sections still reference JS packages (`axios`, `dompurify`) — those are illustrative, not load-bearing; the concepts apply to Python ecosystems. For the JS sibling, see [dependabot-triage](https://github.com/akshayrao14/dependabot-triage).
 
 Agent Skill for triaging and fixing Dependabot vulnerability alerts in Python repos. Covers pip, poetry, uv, pdm, pipenv ecosystems. Compatible with any agent that supports the [Agent Skills standard](https://github.com/anthropics/skills) — Claude Code, Codex CLI, Gemini CLI, Cursor, etc.
 

--- a/skills/dependabot-triage-py/SKILL.md
+++ b/skills/dependabot-triage-py/SKILL.md
@@ -375,9 +375,13 @@ Assumes "Detect package managers in play" (workflow step 1) is already done — 
    - **Verify the target isn't yanked**:
      ```bash
      curl -s "https://pypi.org/pypi/<pkg>/json" \
-       | jq -r '.releases["<target>"][0] | "yanked=\(.yanked) reason=\(.yanked_reason)"'
-     # → "yanked=false reason=null" expected. "yanked=true ..." → pick the next release up.
+       | jq -r --arg t '<target>' \
+           '{yanked: (.releases[$t] | map(.yanked) | any),
+             reasons: (.releases[$t] | map(.yanked_reason) | unique - [null])}'
+     # → {"yanked": false, "reasons": []} expected.
+     # → any file in the release yanked → pick the next release up.
      ```
+     Per-file yanked status *should* be consistent across a release's artifacts, but isn't guaranteed; the `any` form catches the inconsistent case too.
    - **Verify `requires_python` compatibility**:
      ```bash
      curl -s "https://pypi.org/pypi/<pkg>/<target>/json" | jq -r '.info.requires_python'
@@ -388,7 +392,7 @@ Assumes "Detect package managers in play" (workflow step 1) is already done — 
      curl -s "https://pypi.org/pypi/<pkg>/<target>/json" \
        | jq -r '.urls[].filename' | grep -E '\.whl$' | sort
      ```
-     Verify wheels exist for every target platform tag (`manylinux2014_x86_64`, `manylinux2014_aarch64`, `musllinux_*`, `macosx_*`, `win_amd64`) AND every Python version (`cp310`, `cp311`, `cp312`) in the project's matrix. A missing wheel forces a source build on that target — silent CI break (slow build, may fail without compiler/headers).
+     Verify wheels exist for every target platform tag (`manylinux2014_x86_64`, `manylinux2014_aarch64`, `musllinux_*`, `macosx_*`, `win_amd64`) AND every Python version in the project's `requires-python` matrix (read from `project.requires-python` in `pyproject.toml`, or the project's CI test matrix). A missing wheel forces a source build on that target — silent CI break (slow build, may fail without compiler/headers).
    - **Do NOT default to "latest in same major."** Latest maximizes change surface and risks breaking transitives. Only override the defensive minimum when (a) the user explicitly asks, or (b) the minimum is unmaintained / yanked / pulls in its own fresh CVEs.
    - Cap at the same major as currently installed unless the user approves a major bump.
 6. **Changelog scrape** — fetch release notes between current and target version. Try PyPI's project metadata first, then the upstream GitHub:
@@ -396,18 +400,31 @@ Assumes "Detect package managers in play" (workflow step 1) is already done — 
    # 1. Pull PyPI project URLs — Changelog / Release notes are commonly listed
    curl -s "https://pypi.org/pypi/<pkg>/json" | jq -r '.info.project_urls'
 
-   # 2. If a GitHub repo is listed, fetch release notes via gh
+   # 2. If a GitHub repo is listed, fetch release notes via gh.
+   #    Strip trailing .git separately — repo names can contain dots
+   #    (org/foo.bar is valid), so the second path segment is [^/]+, not [^/.]+.
    PKG_REPO=$(curl -s "https://pypi.org/pypi/<pkg>/json" \
      | jq -r '.info.project_urls.Source // .info.project_urls.Repository // .info.project_urls.Homepage // .info.home_page' \
-     | sed -E 's|.*github\.com/([^/]+/[^/.]+).*|\1|')
+     | sed -E 's|.*github\.com/([^/]+/[^/]+).*|\1|; s|\.git$||')
    gh release view "v<target>" --repo "$PKG_REPO" --json tagName,body,createdAt 2>/dev/null \
      || gh release view "<target>" --repo "$PKG_REPO" --json tagName,body,createdAt
 
-   # 3. Fallback: download the sdist and grep the bundled CHANGELOG
-   pip download <pkg>==<target> --no-deps --no-binary=:all: -d /tmp/<pkg>-src/ >/dev/null 2>&1
-   tar -xf /tmp/<pkg>-src/<pkg>-<target>.tar.gz -C /tmp/<pkg>-src/
-   grep -inE 'BREAKING|DEPRECATED|MIGRATION|removed|drop(ped)? support' \
-     /tmp/<pkg>-src/<pkg>-<target>/{CHANGELOG*,CHANGES*,HISTORY*,NEWS*} 2>/dev/null | head -50
+   # 3. Fallback: download the sdist and grep the bundled CHANGELOG.
+   #    Resolve the sdist URL from the same PyPI JSON — distribution-name
+   #    normalization (PyYAML → pyyaml, python-dateutil → python_dateutil)
+   #    makes hand-guessed filenames unreliable.
+   SDIST_URL=$(curl -s "https://pypi.org/pypi/<pkg>/<target>/json" \
+     | jq -r '.urls[] | select(.packagetype=="sdist") | .url' | head -1)
+   if [[ -n "$SDIST_URL" ]]; then
+     SRC=/tmp/<pkg>-<target>
+     mkdir -p "$SRC" && curl -sL "$SDIST_URL" -o "$SRC/sdist.tar.gz"
+     tar -xf "$SRC/sdist.tar.gz" -C "$SRC" --strip-components=1
+     grep -inrE 'BREAKING|DEPRECATED|MIGRATION|removed|drop(ped)? support' \
+       --include='CHANGELOG*' --include='CHANGES*' \
+       --include='HISTORY*' --include='NEWS*' "$SRC" 2>/dev/null | head -50
+   else
+     echo "no sdist published for <pkg>==<target> — wheel-only release; skip sdist changelog fallback"
+   fi
    ```
    Surface the flagged lines verbatim to the user — do not paraphrase. If `BREAKING` / `DEPRECATED` / `MIGRATION` appears, raise the safety interlock to "second confirmation required" before proceeding.
 
@@ -477,7 +494,7 @@ Dropping the marker silently widens install scope (the dep installs on platforms
   - **No universal `^`.** The semver caret is poetry-only — `^X.Y.Z` works in `[tool.poetry.dependencies]`, nowhere else. Use the explicit `>=X.Y.Z,<(X+1).0.0` form for portability across uv / pdm / pip / pipenv.
   - **PEP 440 `~=X.Y.Z`** ("compatible release") is *narrower* than the semver caret: `~=X.Y.Z` means `>=X.Y.Z,<X.(Y+1).0`, i.e. patch-only flexibility. Use only when minor-bump flexibility is unwanted.
   - **Exact pin `==X.Y.Z`** is common in `requirements.txt` for reproducibility. Surface the trade-off to the user (no patch-level updates ride in) before defaulting to exact pin. A hash-pinned `requirements.txt` already has reproducibility via `--require-hashes`; layering `==` on top is redundant unless the project explicitly forbids re-resolves.
-- **For `uv override-dependencies` and `pdm overrides`**, use the full PEP 440 specifier (`<pkg>>=X.Y.Z,<(X+1).0.0`). Bare `<pkg>` or unbounded `>=X.Y.Z` is rejected by the resolver.
+- **For `uv override-dependencies` and `pdm overrides`**, use the full PEP 440 specifier with an upper bound (`<pkg>>=X.Y.Z,<(X+1).0.0`). A bare distribution name with no version part is invalid; an unbounded `>=X.Y.Z` *is* accepted by uv but lets a future major bump ride in silently — same anti-pattern as JS bare `>=` without a caret. Always cap.
 - **Never bare `>=X.Y.Z`** without an upper bound — surprise major bumps. Always cap.
 - **Never `>X.Y.Z`** — excludes the patched version itself, forces `X.Y.Z+1`, no benefit.
 - **Pre-release versions** (`1.0.0a1`, `.rc1`, `.dev1`) are excluded by pip's default resolver unless `--pre` is passed or an exact `==` pin is used. If the only patched version is a pre-release, flag this explicitly — the project may need to opt in to pre-releases or wait for the stable.
@@ -549,7 +566,7 @@ When CI uses a PM that has no committed lockfile (e.g. poetry-local + raw-pip-CI
 | pdm | `pdm lock --no-sync` | `pdm.lock` |
 | pipenv | `pipenv lock` | `Pipfile.lock` |
 | pip-tools | `pip-compile requirements.in` (add `--generate-hashes` if hashed) | `requirements.txt` |
-| pip (raw) | `python -m pip install '<pkg>>=X.Y.Z' --dry-run --report /tmp/pip-resolve.json --quiet`, then `jq '.install[] | select(.metadata.name=="<pkg>") | .metadata.version' /tmp/pip-resolve.json` | (JSON report only, no file commit) |
+| pip (raw) | `python -m pip install '<pkg>>=X.Y.Z' --dry-run --report /tmp/pip-resolve.json --quiet`, then `jq '.install[] | select(.metadata.name=="<pkg>") | .metadata.version' /tmp/pip-resolve.json` — **requires pip ≥ 23.2** (the `--report` JSON format landed in 23.2). Verify with `pip --version` first; older pip silently produces no report. | (JSON report only, no file commit) |
 
 > ⚠ Do **NOT** commit a generated lockfile from a PM that doesn't already have one committed. Dual-lockfile drift is exactly the bug class this skill exists to prevent — a generated `requirements.txt` alongside an authoritative `poetry.lock` will silently diverge on the next regen and you've doubled the surface area, not halved it.
 
@@ -613,7 +630,7 @@ If API confirms fix but UI still shows old count, reassure the user — it's UI 
 
 ## Platform notes
 
-- **Native-wheel risk**: bumps of compiled packages (`cryptography`, `lxml`, `numpy`, `pandas`, `pillow`, `psycopg2`, `cffi`, `bcrypt`, `pyodbc`, `pyarrow`, `grpcio`) can drop a platform wheel between versions. Verify wheels exist for every deploy-target platform tag (`manylinux2014_x86_64`, `manylinux2014_aarch64`, `musllinux_*`, `macosx_*`, `win_amd64`) AND every Python version (`cp310`, `cp311`, `cp312`) in the project's matrix before pinning. A missing wheel forces a source build on that target — silent CI break (slow build, may fail without compiler/headers).
+- **Native-wheel risk**: bumps of compiled packages (`cryptography`, `lxml`, `numpy`, `pandas`, `pillow`, `psycopg2`, `cffi`, `bcrypt`, `pyodbc`, `pyarrow`, `grpcio`) can drop a platform wheel between versions. Verify wheels exist for every deploy-target platform tag (`manylinux2014_x86_64`, `manylinux2014_aarch64`, `musllinux_*`, `macosx_*`, `win_amd64`) AND every Python version in the project's `requires-python` matrix (read from `project.requires-python` in `pyproject.toml`, or the project's CI test matrix) before pinning. A missing wheel forces a source build on that target — silent CI break (slow build, may fail without compiler/headers).
 - **Hash mismatches**: when dev and CI use different index URLs (private PyPI mirror, devpi), hash-pinned requirements can fail with `hash mismatch` — same file, different mirror's hash. Surface this if a hash check fails on a bump that otherwise looks correct.
 - **`requires_python` skew**: bumping to a target whose `requires_python` floor exceeds the project's configured floor (`project.requires-python` / `tool.poetry.dependencies.python`) breaks install on older Python deploys. Check the target's `requires_python` via PyPI metadata before pinning.
 - **Distribution-name normalization**: PyPI normalizes `_` / `-` / `.` and case in distribution names. `pkg_a`, `pkg-a`, `Pkg.A` all refer to the same distribution at resolve time, but lockfile entries may use any of these spellings. When parsing lockfiles, normalize both sides (`.lower().replace('_','-').replace('.','-')`) before comparing names.

--- a/skills/dependabot-triage-py/SKILL.md
+++ b/skills/dependabot-triage-py/SKILL.md
@@ -69,21 +69,44 @@ Detect PMs   →   Fetch + Rank   →   Mode Selection   →   { Standard | Fast
 The early steps (1–4) are the same in both modes. The middle steps branch by mode. The closing steps (regen + parity + PR) are identical and non-negotiable.
 
 1. **Detect package managers in play** — before fetching alerts, figure out which PM(s) actually touch this repo, in *every* context (local install, CI install, container build). The override + parity matrix below depends on this.
-   - **Committed manifests / lockfiles**:
+   - **Committed manifests / lockfiles** — start at repo root, then walk subdirectories for monorepo / multi-Lambda / multi-service layouts:
      ```bash
+     # Root + common manifest types
      ls requirements*.txt requirements*.in pyproject.toml Pipfile Pipfile.lock \
         poetry.lock uv.lock pdm.lock constraints*.txt 2>/dev/null
+
+     # Recursive — multi-package repos (Lambda monorepos, CDK / Serverless,
+     # multi-service workspaces). Excludes vendored / cache dirs.
+     find . \( -name 'requirements*.txt' -o -name 'requirements*.in' \
+              -o -name 'pyproject.toml' -o -name 'Pipfile' \
+              -o -name 'Pipfile.lock' -o -name 'poetry.lock' \
+              -o -name 'uv.lock' -o -name 'pdm.lock' \
+              -o -name 'constraints*.txt' \) \
+       -not -path '*/node_modules/*' -not -path '*/\.venv/*' \
+       -not -path '*/venv/*' -not -path '*/__pycache__/*' \
+       -not -path '*/\.git/*' -not -path '*/\.serverless/*' \
+       -not -path '*/build/*' -not -path '*/dist/*' 2>/dev/null | sort
      ```
+     Dependabot raises one alert per committed manifest, so the same package vulnerable in 3 per-Lambda `requirements.txt` files surfaces as 3 alerts. Per the "Same package in multiple manifests" rule in the branching strategy, the default fix is **one PR touching every affected manifest**.
    - **`pyproject.toml` PM tables** — a single `pyproject.toml` may carry config for more than one PM. Grep for the tables to see which are in play:
      ```bash
      rg -n '^\[(tool\.(poetry|pdm|uv)|project|build-system)\]' pyproject.toml 2>/dev/null
      ```
-   - **CI / container install commands** — grep CI configs and Dockerfiles for the actual install command:
+   - **CI / container / framework install commands** — grep CI configs, Dockerfiles, AND Python-deploy framework manifests for the actual install command. Lambda repos especially deploy pip *implicitly* through a framework plugin, not an explicit `pip install` line:
      ```bash
      rg -tg '*.yml' -tg '*.yaml' \
        '\b(pip (install|sync)|poetry (install|lock|sync)|uv (sync|pip|lock)|pdm (install|sync|lock)|pipenv (install|sync|lock)|pip-compile)\b' \
-       .github .gitlab-ci.yml Dockerfile* docker-compose*.yml circle.yml .circleci 2>/dev/null
+       .github .gitlab-ci.yml Dockerfile* docker-compose*.yml circle.yml .circleci \
+       serverless.yml serverless.yaml template.yaml template.yml \
+       cdk.json samconfig.toml 2>/dev/null
      ```
+   - **Implicit-resolve Python frameworks** — common deploy patterns where pip is invoked by a plugin/framework, not directly. The `pip install` line won't appear in CI; the framework manifest is the real driver:
+     - **Serverless Framework** (`serverless.yml` + `serverless-python-requirements` plugin) — each Lambda function may carry its own `requirements.txt`; plugin auto-resolves on `sls deploy`. Look for `fileName:` keys pointing at `requirements*.txt` paths and per-function `package:` blocks.
+     - **AWS SAM** (`template.yaml`) — each Lambda function's `CodeUri:` directory may contain its own `requirements.txt`; `sam build` calls pip per function.
+     - **AWS CDK** (`cdk.json` + `app.py`) — Python Lambdas built via the `PythonFunction` construct or Docker bundling; per-construct `requirements.txt` resolved at synth/deploy time.
+     - **Zappa** (`zappa_settings.json`) — single-project pip deploy.
+
+     These patterns hide the per-Lambda manifest split behind the framework. The recursive `find` above will surface every `requirements*.txt`; cross-reference each with the deploy manifest to figure out which Lambda owns it.
    - **Compare** committed manifests against CI install commands. If CI uses a different PM than the committed lockfile (e.g. `poetry.lock` committed but the Dockerfile runs `pip install -r requirements.txt`), expand the override + parity matrix accordingly (see "Override pattern" and "Verify (Parity Check)").
    - **Hash-pinned requirements flag** — if any `requirements*.txt` contains `--hash=sha256:` lines, this is a `pip-tools --generate-hashes` setup. Bumps require regenerating hashes; forgetting will break `pip install --require-hashes` in CI/prod.
    - **Don't ask the user up-front to classify the PM setup.** They often only know half the picture (their local context, not CI; or vice versa). Detect from manifest/lockfile + CI grep, show what was found, and ask only to confirm anomalies (e.g. *"I see `poetry.lock` committed but the Dockerfile runs `pip install -r requirements.txt` — confirm both are intentional?"*).
@@ -206,6 +229,8 @@ Three axes, in order:
 1. **Impact** — RCE > data exfil/SSRF > DoS > logic bugs
 2. **Exposure** — see Exposure Mapping below. NOT a heuristic guess about whether the vuln is reachable. A categorization of where the package is imported, presented to the user as a surface-area summary.
 3. **CVSS** — tiebreaker only. Raw score without exposure context misleads (e.g. SSRF in axios shows 4.8 but matters more if axios is in Public/API).
+
+> **CVSS=0 fallback.** Dependabot returns `security_advisory.cvss.score: 0` (or `null`) when the advisory hasn't been scored yet — common for fresh GHSAs. Don't let an unscored alert sink to the bottom of a CVSS-sorted ranking; fall back to `security_advisory.severity` (always populated). Approximate score mapping: `critical` ≈ 9.5, `high` ≈ 7.5, `medium` ≈ 5.0, `low` ≈ 2.0. Surface the fallback explicitly in the ranked table — e.g. `cvss: — (high)` rather than `cvss: 0` — so the user understands why a high-severity alert sits above a low-CVSS one.
 
 ## Exposure Mapping
 

--- a/skills/dependabot-triage-py/SKILL.md
+++ b/skills/dependabot-triage-py/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: dependabot-triage-py
-description: '[scaffold — Python-specific blocks pending] Triage and fix Dependabot vulnerability alerts in Python repos (pip, poetry, uv, pdm, pipenv). v2.1 workflow with Standard (defensive) and Fast-Track (low-risk) modes — defensive minimal-patched versioning (PEP 440 ranges), exposure mapping (Public/API · Internal/Dev), CI workflow inspection, mandatory lockfile parity check across every PM that touches pyproject.toml / requirements*.txt, changelog scrape with BREAKING/DEPRECATED/MIGRATION flagging, and safety interlock before applying bumps. Fast-Track mode skips changelog + detailed exposure for Internal/Dev or CVSS<7 alerts, but parity check + dual-write are non-negotiable. Use when the user shares a Dependabot URL for a Python repo, asks to fix CVEs in a Python project, or asks which Python vulnerability to pick first.'
+description: Triage and fix Dependabot vulnerability alerts in Python repos (pip, poetry, uv, pdm, pipenv). v2.1 workflow with Standard (defensive) and Fast-Track (low-risk) modes — defensive minimal-patched versioning (PEP 440 ranges), exposure mapping (Public/API · Internal/Dev), CI workflow inspection to detect every PM in play, mandatory lockfile parity check across every PM that touches pyproject.toml / requirements*.txt, changelog scrape with BREAKING/DEPRECATED/MIGRATION flagging, and safety interlock before applying bumps. Fast-Track mode skips changelog + detailed exposure for Internal/Dev or CVSS<7 alerts, but parity check + dual-write are non-negotiable. Use when the user shares a Dependabot URL for a Python repo, asks to fix CVEs in a Python project, or asks which Python vulnerability to pick first.
 ---
 
 # Dependabot Triage & Fix — Python (v2.1)
-
-> **Scaffold — not yet feature-complete.** Shared workflow is wired in; Python-specific blocks are marked `<!-- TODO(py): ... -->` and will be fleshed out in a follow-up. Some shared examples reference JS packages (axios, dompurify) — those are illustrative; the concepts apply to Python ecosystems.
 
 ## v2.1 highlights
 
@@ -70,31 +68,32 @@ Detect PMs   →   Fetch + Rank   →   Mode Selection   →   { Standard | Fast
 
 The early steps (1–4) are the same in both modes. The middle steps branch by mode. The closing steps (regen + parity + PR) are identical and non-negotiable.
 
-1. **Detect package managers in play** —
-   <!-- TODO(py): full PM detection block.
-        Committed manifests/lockfiles:
-          - requirements*.txt / requirements*.in (pip / pip-tools)
-          - Pipfile + Pipfile.lock (pipenv)
-          - pyproject.toml [tool.poetry] + poetry.lock
-          - pyproject.toml [tool.pdm] + pdm.lock
-          - pyproject.toml [project] + uv.lock (uv)
-          - constraints.txt (pip constraints — referenced via `-c`)
-        CI / container install grep:
-          - pip install -r ... / pip install --constraint ...
-          - poetry install / poetry lock
-          - uv sync / uv pip compile / uv pip install
-          - pdm install / pdm sync
-          - pipenv install / pipenv sync
-          - pip-compile
-        Mirror the JS step-1 "compare committed vs CI" logic.
-        Flag hash-pinned requirements (pip-tools `--generate-hashes`) — bump
-        breaks `pip install --require-hashes` unless hashes are regenerated. -->
+1. **Detect package managers in play** — before fetching alerts, figure out which PM(s) actually touch this repo, in *every* context (local install, CI install, container build). The override + parity matrix below depends on this.
+   - **Committed manifests / lockfiles**:
+     ```bash
+     ls requirements*.txt requirements*.in pyproject.toml Pipfile Pipfile.lock \
+        poetry.lock uv.lock pdm.lock constraints*.txt 2>/dev/null
+     ```
+   - **`pyproject.toml` PM tables** — a single `pyproject.toml` may carry config for more than one PM. Grep for the tables to see which are in play:
+     ```bash
+     rg -n '^\[(tool\.(poetry|pdm|uv)|project|build-system)\]' pyproject.toml 2>/dev/null
+     ```
+   - **CI / container install commands** — grep CI configs and Dockerfiles for the actual install command:
+     ```bash
+     rg -tg '*.yml' -tg '*.yaml' \
+       '\b(pip (install|sync)|poetry (install|lock|sync)|uv (sync|pip|lock)|pdm (install|sync|lock)|pipenv (install|sync|lock)|pip-compile)\b' \
+       .github .gitlab-ci.yml Dockerfile* docker-compose*.yml circle.yml .circleci 2>/dev/null
+     ```
+   - **Compare** committed manifests against CI install commands. If CI uses a different PM than the committed lockfile (e.g. `poetry.lock` committed but the Dockerfile runs `pip install -r requirements.txt`), expand the override + parity matrix accordingly (see "Override pattern" and "Verify (Parity Check)").
+   - **Hash-pinned requirements flag** — if any `requirements*.txt` contains `--hash=sha256:` lines, this is a `pip-tools --generate-hashes` setup. Bumps require regenerating hashes; forgetting will break `pip install --require-hashes` in CI/prod.
+   - **Don't ask the user up-front to classify the PM setup.** They often only know half the picture (their local context, not CI; or vice versa). Detect from manifest/lockfile + CI grep, show what was found, and ask only to confirm anomalies (e.g. *"I see `poetry.lock` committed but the Dockerfile runs `pip install -r requirements.txt` — confirm both are intentional?"*).
 2. **Fetch alerts**:
-   <!-- TODO(py): mirror JS step 2 — filter `.dependency.package.ecosystem == "pip"`.
-        Mixed-ecosystem repos: surface non-pip alerts as out-of-scope.
-        Dependabot's pip ecosystem sometimes flags packages installed via apt/system
-        Docker base images, not pip — verify the package is actually in pip's
-        resolved tree (lockfile or `pip list`) before applying. -->
+   - Repo URL → `gh api "repos/<org>/<repo>/dependabot/alerts?state=open&per_page=100"`
+   - Org URL → only after explicit user confirmation, then `gh api "orgs/<org>/dependabot/alerts?state=open&per_page=100"` (paginates across every repo).
+   - Filter `.dependency.package.ecosystem == "pip"` for this skill; surface non-Python alerts as out-of-scope.
+   - Dedupe by `(repo, package)`.
+   - **Mixed-ecosystem repos (Python + npm, Go + Python, etc.):** group alerts by ecosystem BEFORE presenting the ranked table. Output out-of-scope ecosystems as a separate blocked section at the top — e.g. "⛔ Out of scope for this skill (handle separately): axios × 6 (npm), lodash × 2 (npm)." The user needs to see what's NOT being covered so they can act on it elsewhere. Never silently drop non-Python alerts.
+   - **System-package false positives**: Dependabot's `pip` ecosystem occasionally flags packages installed via apt / Docker base images, not pip. Before applying, verify the package actually appears in pip's resolved tree (in the lockfile or `pip list` output). If absent from pip but present in the system, the fix is a base-image bump, not a pip override.
 3. **Rank** using the prioritization framework (Impact × Exposure × CVSS).
 4. **Read advisory** for the top pick — extract `first_patched_version`, `vulnerable_version_range`, and `cvss.score`. For clusters, compute the *minimal* version that supersets every CVE patch.
 5. **Mode selection — recommend Fast-Track or Standard.** See "Fast-Track mode" section for the eligibility rules. Present a one-liner recommendation alongside the ranked summary, e.g. *"This is a dev-dependency; would you like to Fast-Track this fix?"* Default to Standard if the user is silent or ambiguous. Also default to Standard when no lockfile is committed for the CI PM — every CI build re-resolves transitives fresh, the override field is the only pin, and the case is Fast-Track-ineligible (no lockfile parity to check).
@@ -114,23 +113,9 @@ The early steps (1–4) are the same in both modes. The middle steps branch by m
 ### Apply (steps 9–13) — identical in both modes, non-negotiable
 
 9. **Confirm branching strategy AND base branch.** Detect default branch via `gh repo view --json defaultBranchRef`; never hardcode `main`. Default: one PR per package off latest `origin/<detected-base>`.
-10. **Edit the manifest(s)** —
-    <!-- TODO(py): per-PM edit instructions.
-         - poetry: pin in [tool.poetry.dependencies] or [tool.poetry.group.*.dependencies]
-         - uv: [tool.uv] override-dependencies = ["pkg>=X.Y.Z"]
-         - pdm: [tool.pdm.resolution] overrides = { "pkg" = ">=X.Y.Z" }
-         - pip (raw) / pipenv: NO transitive override mechanism — must bump the
-           parent dep or use constraints.txt for pip.
-         Required in BOTH modes. Preserve environment markers and extras. -->
-11. **Regenerate every relevant lockfile** —
-    <!-- TODO(py): per-PM regen commands.
-         - poetry: poetry lock --no-update
-         - uv: uv lock
-         - pdm: pdm lock
-         - pipenv: pipenv lock
-         - pip-tools: pip-compile (with --generate-hashes if hash-pinned)
-         For PMs without a committed lockfile, generate temp + delete before commit. -->
-12. **Parity check** — for each PM detected in step 1, read its lockfile and assert every PM resolved to the *same* version of the target package. **Mismatch → abort PR in BOTH modes.**
+10. **Edit the manifest(s)** — write the override into *every* PM detected in step 1 (see "Override pattern"). Required in BOTH modes. Preserve environment markers (`; python_version >= '3.10'`) and extras (`cryptography[ssh]`) when editing.
+11. **Regenerate every relevant lockfile** — for each PM detected in step 1, run its lockfile-only regen. For PMs without a committed lockfile (e.g. raw `pip install -r` setups), regenerate a temp lockfile *just for the parity check* and **delete it before commit** (see "Verify (Parity Check)"). No "primary" lockfile.
+12. **Parity check** — for each PM detected in step 1, read its lockfile and assert every PM resolved to the *same* version of the target package. **Mismatch → abort PR in BOTH modes.** See "Verify (Parity Check)" for the commands.
 13. **Commit on the branch and open a PR** — with explicit user OK before pushing.
 
 ## What Claude will NOT do without confirmation
@@ -228,37 +213,64 @@ Replaces the prior heuristic "reachability" model. Goal: stop trying to PROVE a 
 
 ### Categories
 
-<!-- TODO(py): two-category table (Client-Bundle dropped — Python rarely ships to browser).
-     - **Public/API**: Django views.py / urls.py / middleware.py / consumers.py (ASGI),
-       Flask/FastAPI/Starlette route decorators, AIOHTTP handlers, gRPC servicers,
-       Lambda entry handlers, Celery tasks consuming external input,
-       WSGI/ASGI entrypoints (wsgi.py, asgi.py).
-     - **Internal/Dev**: setup.py, setup.cfg, pyproject.toml [build-system], conftest.py,
-       tests/, scripts/, tox.ini, noxfile.py, Makefile-driven scripts, Sphinx config.
-     Note: Streamlit / Gradio / Dash apps ship Python server-side — treat as Public/API. -->
+Two categories (the JS skill's Client-Bundle drops — Python rarely ships to a browser):
+
+| Category | Definition | Example file paths |
+|---|---|---|
+| **Public/API** | Code that serves HTTP/RPC/webhook traffic from outside the trust boundary. Attacker-controlled input flows in. | Django `views.py` / `urls.py` / `middleware.py` / `consumers.py` (ASGI), FastAPI / Flask / Starlette route decorators, AIOHTTP handlers, gRPC servicers, Lambda entry handlers, Celery tasks consuming external input, `wsgi.py` / `asgi.py` entrypoints |
+| **Internal/Dev** | Build, tooling, scripts, tests, configs. Does NOT run in prod request path. | `setup.py`, `setup.cfg`, `pyproject.toml [build-system]`, `conftest.py`, `tests/`, `scripts/`, `tox.ini`, `noxfile.py`, Sphinx config, Makefile-driven scripts |
+
+> Streamlit / Gradio / Dash apps ship Python server-side — treat as Public/API. PyScript / Brython are rare Python-in-browser cases; if encountered, route through the JS skill's Client-Bundle lens.
 
 ### How to enumerate import sites
 
-<!-- TODO(py): enumeration commands.
-     Key gotcha: PyPI distribution name != Python import name often.
-     Examples: PyYAML/yaml, Pillow/PIL, opencv-python/cv2, scikit-learn/sklearn,
-     beautifulsoup4/bs4, python-dateutil/dateutil.
+PyPI distribution name does NOT always match the Python import name. Common mismatches:
 
-     Resolve dist→import via:
-       python -c "from importlib.metadata import packages_distributions; \
-         print({m: d for m, d in packages_distributions().items() if '<dist>' in d})"
-     (Requires Python 3.10+; use `importlib_metadata` backport for 3.8/3.9.)
+| PyPI distribution | Python import |
+|---|---|
+| `PyYAML` | `yaml` |
+| `Pillow` | `PIL` |
+| `opencv-python` | `cv2` |
+| `scikit-learn` | `sklearn` |
+| `beautifulsoup4` | `bs4` |
+| `python-dateutil` | `dateutil` |
+| `protobuf` | `google.protobuf` |
+| `python-jose` | `jose` |
 
-     Then grep with the import name:
-       rg -t py "^(import |from ) *<import-name>([. ]|$)" -l | sort -u -->
+Resolve dist→import via `importlib.metadata.packages_distributions()` (Python 3.10+; use the `importlib_metadata` backport for 3.8/3.9):
+
+```bash
+python -c "from importlib.metadata import packages_distributions; \
+  d=packages_distributions(); \
+  print(sorted({m for m, dists in d.items() if '<dist>' in dists}))"
+```
+
+Then grep with each import name:
+
+```bash
+# Prefer ripgrep (fast, respects .gitignore)
+rg -t py "^[[:space:]]*(import|from)[[:space:]]+<import-name>([. ]|$)" -l | sort -u
+
+# Fallback to grep
+grep -rE "^[[:space:]]*(import|from)[[:space:]]+<import-name>([. ]|$)" \
+  --include='*.py' -l . | grep -v -E '/(\.venv|venv|__pycache__|\.tox|\.eggs|build|dist)/' | sort -u
+```
+
+Then bucket each path by matching against the Categories table. Paths that don't fit cleanly → ask the user, do not guess.
 
 ### How to present to the user
 
-<!-- TODO(py): adapt JS surface-summary format; drop Client-Bundle row.
-     Example output:
-       Exposure surface for requests in webhook-api:
-         Public/API     : 8 sites (e.g. app/routes/webhook.py, services/external.py, ...)
-         Internal/Dev   : 2 sites (e.g. tests/conftest.py, scripts/seed.py, ...) -->
+Output as a surface summary, not a verdict:
+
+```
+Exposure surface for requests in webhook-api:
+  Public/API     : 8 sites (e.g. app/routes/webhook.py, services/external_client.py, ...)
+  Internal/Dev   : 2 sites (e.g. tests/conftest.py, scripts/seed_data.py, ...)
+```
+
+If a single import site straddles categories (e.g. a util re-exported from both a route handler and a test helper), it inherits the highest-risk category present.
+
+The user reads the surface and decides whether the bump is worth the risk — Claude does not say "this is reachable" or "this is unreachable".
 
 ### Cross-repo / org-wide ranking (opt-in)
 
@@ -333,103 +345,252 @@ Do NOT use `--force` (without lease) — it skips the safety check that aborts i
 
 Assumes "Detect package managers in play" (workflow step 1) is already done — the override + parity matrix below depends on knowing which PMs touch this repo.
 
-<!-- TODO(py): workflow-per-alert numbered steps 1–8.
-     1. Dedupe: GitHub raises one alert per committed lockfile.
-     2. Get advisory: same `gh api repos/.../dependabot/alerts/<n>` — extract
-        first_patched_version, vulnerable_version_range, cvss.score.
-        Note: some Python alerts have GHSA only, no CVE — accept GHSA-prefix.
-     3. Locate: parse poetry.lock / uv.lock TOML, pdm.lock, Pipfile.lock JSON,
-        or requirements.txt.
-     4. Exposure Mapping: see Categories above.
-     5. Pick version (defensive minimal-patched, PEP 440):
-        - Single alert: >=X.Y.Z,<(X+1).0.0 of first_patched_version
-        - Cluster: same shape, X.Y.Z = max(first_patched_version) across cluster
-        - Verify NOT yanked via PyPI .releases[<ver>][0].yanked
-        - Check requires_python on PyPI doesn't exceed project's python_requires
-        - Verify wheel availability for every deploy-target platform/Python combo
-     6. Changelog scrape: PyPI project_urls.Changelog / Release notes URL via
-        `curl -s https://pypi.org/pypi/<pkg>/json | jq -r '.info.project_urls'`,
-        fall back to GitHub release notes (`gh release view`).
-     7. Safety interlock — PAUSE (identical to JS).
-     8. After user OK: edit manifest(s), regen lockfile(s), run Parity Check,
-        commit, ask before push. -->
+1. **Dedupe**: GitHub raises one alert per committed manifest/lockfile. A repo with both `requirements.txt` AND `pyproject.toml` may raise two alerts for the same vuln. Fix the package once; cover every PM in the override.
+2. **Get advisory**: `gh api repos/<org>/<repo>/dependabot/alerts/<n>` — extract `first_patched_version`, `vulnerable_version_range`, and `cvss.score`. The list endpoint hides these. For clusters, fetch every alert in the cluster. Python advisories may have a GHSA identifier only (no CVE) — accept GHSA-prefix advisories the same way.
+3. **Locate**: direct dep (in `pyproject.toml` / `requirements*.in` / `Pipfile [packages]`) or transitive? Parse the relevant lockfile:
+   ```bash
+   # poetry.lock — TOML; dependents of <pkg>
+   python -c "import tomllib; d=tomllib.load(open('poetry.lock','rb')); \
+     print([(p['name'], p['version']) for p in d['package'] \
+            if '<pkg>' in (p.get('dependencies') or {})])"
+
+   # uv.lock / pdm.lock — same TOML shape (key is `package`)
+
+   # Pipfile.lock — JSON
+   jq '(.default + .develop) | to_entries[]
+       | select(.value.dependencies // {} | has("<pkg>"))
+       | {name: .key, version: .value.version}' Pipfile.lock
+   ```
+4. **Exposure Mapping**: see "Exposure Mapping" section. Categorize every import site (Public/API · Internal/Dev) and produce a surface summary for the user.
+5. **Pick version (defensive minimal-patched, PEP 440)**:
+   - Single alert: `>=X.Y.Z,<(X+1).0.0` of `first_patched_version`.
+   - Cluster: same shape, `X.Y.Z = max(first_patched_version)` across every CVE in the cluster — i.e. the *minimal* version that supersets every patch. Compute via:
+     ```bash
+     for n in <alert-numbers>; do
+       gh api repos/<org>/<repo>/dependabot/alerts/$n \
+         --jq '.security_advisory.vulnerabilities[0].first_patched_version.identifier'
+     done | python -c "import sys; from packaging.version import Version; \
+       vs=[Version(l.strip()) for l in sys.stdin if l.strip()]; print(max(vs))"
+     ```
+   - **Verify the target isn't yanked**:
+     ```bash
+     curl -s "https://pypi.org/pypi/<pkg>/json" \
+       | jq -r '.releases["<target>"][0] | "yanked=\(.yanked) reason=\(.yanked_reason)"'
+     # → "yanked=false reason=null" expected. "yanked=true ..." → pick the next release up.
+     ```
+   - **Verify `requires_python` compatibility**:
+     ```bash
+     curl -s "https://pypi.org/pypi/<pkg>/<target>/json" | jq -r '.info.requires_python'
+     ```
+     If the target's floor exceeds the project's configured floor (`project.requires-python` or `tool.poetry.dependencies.python` in `pyproject.toml`), the bump breaks install on older deploy targets. Surface to user.
+   - **Wheel availability across deploy targets** — for compiled packages (cryptography, lxml, numpy, pandas, pillow, psycopg2, cffi, bcrypt, pyarrow, grpcio), list available wheels:
+     ```bash
+     curl -s "https://pypi.org/pypi/<pkg>/<target>/json" \
+       | jq -r '.urls[].filename' | grep -E '\.whl$' | sort
+     ```
+     Verify wheels exist for every target platform tag (`manylinux2014_x86_64`, `manylinux2014_aarch64`, `musllinux_*`, `macosx_*`, `win_amd64`) AND every Python version (`cp310`, `cp311`, `cp312`) in the project's matrix. A missing wheel forces a source build on that target — silent CI break (slow build, may fail without compiler/headers).
+   - **Do NOT default to "latest in same major."** Latest maximizes change surface and risks breaking transitives. Only override the defensive minimum when (a) the user explicitly asks, or (b) the minimum is unmaintained / yanked / pulls in its own fresh CVEs.
+   - Cap at the same major as currently installed unless the user approves a major bump.
+6. **Changelog scrape** — fetch release notes between current and target version. Try PyPI's project metadata first, then the upstream GitHub:
+   ```bash
+   # 1. Pull PyPI project URLs — Changelog / Release notes are commonly listed
+   curl -s "https://pypi.org/pypi/<pkg>/json" | jq -r '.info.project_urls'
+
+   # 2. If a GitHub repo is listed, fetch release notes via gh
+   PKG_REPO=$(curl -s "https://pypi.org/pypi/<pkg>/json" \
+     | jq -r '.info.project_urls.Source // .info.project_urls.Repository // .info.project_urls.Homepage // .info.home_page' \
+     | sed -E 's|.*github\.com/([^/]+/[^/.]+).*|\1|')
+   gh release view "v<target>" --repo "$PKG_REPO" --json tagName,body,createdAt 2>/dev/null \
+     || gh release view "<target>" --repo "$PKG_REPO" --json tagName,body,createdAt
+
+   # 3. Fallback: download the sdist and grep the bundled CHANGELOG
+   pip download <pkg>==<target> --no-deps --no-binary=:all: -d /tmp/<pkg>-src/ >/dev/null 2>&1
+   tar -xf /tmp/<pkg>-src/<pkg>-<target>.tar.gz -C /tmp/<pkg>-src/
+   grep -inE 'BREAKING|DEPRECATED|MIGRATION|removed|drop(ped)? support' \
+     /tmp/<pkg>-src/<pkg>-<target>/{CHANGELOG*,CHANGES*,HISTORY*,NEWS*} 2>/dev/null | head -50
+   ```
+   Surface the flagged lines verbatim to the user — do not paraphrase. If `BREAKING` / `DEPRECATED` / `MIGRATION` appears, raise the safety interlock to "second confirmation required" before proceeding.
+
+   **Transitive-dep qualifier:** Before demanding a second confirmation, check whether the flagged package has any direct import sites in source (from the Exposure Mapping step). If zero direct imports exist — the package is purely transitive — state this explicitly alongside the flag: *"This flag appears in a package that is not directly imported by your source code. The breaking change is unlikely to affect you unless your code parses its error messages or hooks into its internals."* This collapses two confirmation rounds into one when the flag is clearly irrelevant to the calling code.
+7. **Safety interlock — PAUSE.** Print to the user:
+   - chosen target version + reason (defensive minimal vs latest, why)
+   - exposure surface (counts per category, sample paths)
+   - changelog flags (verbatim lines, or "no flags" if clean)
+   - wheel-availability check result (if the package is compiled)
+   - `requires_python` skew flag (if the target's floor exceeds the project's)
+
+   Wait for explicit go-ahead. If changelog flags were raised, require an unambiguous "yes, continue" / "I've handled it" — silence or ambiguous reply means stop.
+
+8. After user OK: edit manifest(s), regen lockfile(s), run Parity Check, commit, ask before push.
 
 ## Override pattern (Python)
 
-<!-- TODO(py): per-PM override mechanisms.
-     Dual-write semantics: write the override into EVERY PM that touches the project.
+Use overrides for:
+- **Transitive vulns** — package not in `[project.dependencies]` / `[tool.poetry.dependencies]` / `[packages]`. The override mechanism is the only fix without bumping a parent.
+- **Direct deps where transitives ALSO request the package** — bumping the direct dep doesn't guarantee transitives get the same resolved version (the resolver may pick a different one for a transitive's range). Add the override anyway as defense-in-depth.
 
-     | PM | Override field | Regen command |
-     |---|---|---|
-     | pip (raw) | NO TRANSITIVE OVERRIDE — pin in requirements.txt or use constraints.txt | `pip install -r requirements.txt -c constraints.txt` |
-     | pip-tools | `*.in` source + compiled `*.txt` (with --generate-hashes if used) | `pip-compile requirements.in` |
-     | poetry | `[tool.poetry.dependencies]` direct pin; transitive needs explicit `poetry add` | `poetry lock --no-update` |
-     | uv | `[tool.uv] override-dependencies = ["pkg>=X.Y.Z"]` | `uv lock` |
-     | pdm | `[tool.pdm.resolution] overrides = { "pkg" = ">=X.Y.Z" }` | `pdm lock` |
-     | pipenv | Edit Pipfile [packages]; NO transitive override mechanism | `pipenv lock` |
+### Dual-write is MANDATORY
 
-     CRITICAL: raw pip and pipenv have NO transitive-override mechanism. If a
-     transitive bump is required and only pip/pipenv are in play, the only fix is
-     to bump the parent dep or migrate to uv/pdm. Hard-ineligible for Fast-Track.
+Write the override field for **every PM detected in step 1**. Different PMs honor *different* mechanisms — and crucially, **raw pip and pipenv have NO transitive-override mechanism at all**:
 
-     Preserve environment markers (e.g. `; python_version >= '3.10'`) and extras
-     (e.g. `cryptography[ssh]>=42.0.0`) when overriding. -->
+| PM | Override mechanism | Regen command |
+|---|---|---|
+| pip (raw) | NO TRANSITIVE OVERRIDE — pin the package directly in `requirements.txt`, or use a `constraints.txt` referenced via `pip install -c constraints.txt` | `pip install -r requirements.txt -c constraints.txt` (no committed lockfile — temp resolve for parity check only) |
+| pip-tools | Edit `requirements.in` (or add a constraint); `pip-compile` re-resolves into `requirements.txt` | `pip-compile requirements.in` (add `--generate-hashes` if the existing file uses hashes) |
+| poetry | `[tool.poetry.dependencies]` for direct pin. For a transitive, poetry has no override *field* — `poetry add <pkg>@>=X.Y.Z,<(X+1).0.0` adds it as an explicit direct dep (the only mechanism). | `poetry lock --no-update` |
+| uv | `[tool.uv] override-dependencies = ["<pkg>>=X.Y.Z,<(X+1).0.0"]` | `uv lock` |
+| pdm | `[tool.pdm.resolution] overrides = { "<pkg>" = ">=X.Y.Z,<(X+1).0.0" }` | `pdm lock` |
+| pipenv | Edit `[packages]` in `Pipfile` for direct pin; NO transitive override mechanism | `pipenv lock` |
+
+Writing to only one when more than one PM is in play produces **environment drift**: developers see one resolved version locally, CI ships another. This is exactly the bug class this skill exists to prevent. Write the override into every relevant field with the same target range, every time, even if only one lockfile is currently committed.
+
+A common Python pattern in this org: `poetry.lock` committed for local dev + an exported `requirements.txt` consumed by the prod Docker image. Both manifests must carry the override (poetry's `[tool.poetry.dependencies]` direct pin AND the regenerated `requirements.txt` from `poetry export`).
+
+### No-transitive-override case (raw pip / pipenv only)
+
+If the only PMs in play are raw pip and/or pipenv, AND the bump is transitive (the vulnerable package is not a direct dep), there is no override mechanism available. The fix paths are:
+
+1. **Bump the parent dep** that pulls in the vulnerable transitive — if the parent's newer version has migrated to a patched range. (Often the right answer.)
+2. **Migrate to a PM with overrides** (uv or pdm) — a project-level change, out of scope for a single security PR.
+3. **Add the transitive as an explicit direct dep** with the patched pin in `requirements.txt` / `Pipfile [packages]`. Surface to the user: this changes the dep graph and may not be the right answer if the parent later drops the transitive.
+
+**Fast-Track is hard-ineligible in this case** — the no-override-mechanism constraint forces option (1) or (3), which deserve Standard's full visibility (changelog scrape + exposure surface + safety interlock).
+
+### Preserve environment markers and extras
+
+When applying the override, preserve any environment markers and extras already present on the dep:
+
+```toml
+# Before
+"<pkg>[extra1,extra2] ; python_version >= '3.10' and platform_system != 'Windows'"
+
+# After (override applied as version pin)
+"<pkg>[extra1,extra2]>=X.Y.Z,<(X+1).0.0 ; python_version >= '3.10' and platform_system != 'Windows'"
+```
+
+Dropping the marker silently widens install scope (the dep installs on platforms/Python versions it shouldn't); dropping extras silently disables feature-gated functionality.
 
 ## Version range rules
 
-<!-- TODO(py): PEP 440 semantics — NOT semver.
-     - Default to defensive minimal patched. Use `>=X.Y.Z,<(X+1).0.0` where
-       X.Y.Z is the *minimal* version that supersets every applicable CVE patch.
-       (Universal — works in poetry, uv, pdm, pipenv, pip.)
-     - Poetry-only alias: `^X.Y.Z` (caret) — same as `>=X.Y.Z,<(X+1).0.0`.
-       Don't use in non-poetry contexts; not PEP 440 standard.
-     - Never use bare `>=X.Y.Z` without an upper bound (anti-major-bump).
-     - PEP 440 `~=X.Y.Z` (compatible release) is FINER than caret: `~=X.Y.Z`
-       means `>=X.Y.Z,<X.(Y+1).0`. Use only when minor-only flexibility wanted.
-     - For uv `override-dependencies` and pdm `overrides`, use full PEP 440
-       specifier (e.g. `pkg>=X.Y.Z,<(X+1).0.0`).
-     - Exact pin `==X.Y.Z` is common in `requirements.txt` for reproducibility;
-       surface trade-off (no patch-level updates) to user before defaulting to exact pin.
-     - Pre-release versions (1.0.0a1, .rc1, .dev1) are excluded by pip default unless
-       `--pre` flag or exact `==` pin. If the only patched version is pre-release,
-       flag explicitly. -->
+- **Default to defensive minimal patched.** Use `>=X.Y.Z,<(X+1).0.0` where `X.Y.Z` is the *minimal* version that supersets every applicable CVE patch (single alert: `first_patched_version`; cluster: `max(first_patched_version)` across the cluster). Universal across pip, poetry, uv, pdm, pipenv. Latest-in-major is opt-in only — its larger change surface raises the chance the bump itself breaks something.
+- **PEP 440 ≠ semver.** Critical syntax differences:
+  - **No universal `^`.** The semver caret is poetry-only — `^X.Y.Z` works in `[tool.poetry.dependencies]`, nowhere else. Use the explicit `>=X.Y.Z,<(X+1).0.0` form for portability across uv / pdm / pip / pipenv.
+  - **PEP 440 `~=X.Y.Z`** ("compatible release") is *narrower* than the semver caret: `~=X.Y.Z` means `>=X.Y.Z,<X.(Y+1).0`, i.e. patch-only flexibility. Use only when minor-bump flexibility is unwanted.
+  - **Exact pin `==X.Y.Z`** is common in `requirements.txt` for reproducibility. Surface the trade-off to the user (no patch-level updates ride in) before defaulting to exact pin. A hash-pinned `requirements.txt` already has reproducibility via `--require-hashes`; layering `==` on top is redundant unless the project explicitly forbids re-resolves.
+- **For `uv override-dependencies` and `pdm overrides`**, use the full PEP 440 specifier (`<pkg>>=X.Y.Z,<(X+1).0.0`). Bare `<pkg>` or unbounded `>=X.Y.Z` is rejected by the resolver.
+- **Never bare `>=X.Y.Z`** without an upper bound — surprise major bumps. Always cap.
+- **Never `>X.Y.Z`** — excludes the patched version itself, forces `X.Y.Z+1`, no benefit.
+- **Pre-release versions** (`1.0.0a1`, `.rc1`, `.dev1`) are excluded by pip's default resolver unless `--pre` is passed or an exact `==` pin is used. If the only patched version is a pre-release, flag this explicitly — the project may need to opt in to pre-releases or wait for the stable.
+- If the defensive minimum is yanked, unmaintained, or itself triggers fresh CVEs, escalate to the user — present the next-newest candidate plus its changelog scrape and let the user pick.
 
 ## Verify (Parity Check)
 
-<!-- TODO(py): per-PM patched-version resolution + parity assertion.
-     For each detected PM, read the lockfile (or query the PM directly) and
-     assert it resolves the target package to >= minimal_patched_version.
+Two checks. Both must pass before the PR is opened. Run for **every PM detected in step 1**, not just one.
 
-     ```bash
-     # poetry: parse poetry.lock (TOML) for the resolved version
-     POETRY_VER=$(python -c "import tomllib; \
-       d=tomllib.load(open('poetry.lock','rb')); \
-       print(next((p['version'] for p in d['package'] if p['name']=='<pkg>'), ''))")
+### 1. Patched-version resolution
 
-     # uv: parse uv.lock (TOML)
-     UV_VER=$(python -c "import tomllib; \
-       d=tomllib.load(open('uv.lock','rb')); \
-       print(next((p['version'] for p in d.get('package',[]) if p['name']=='<pkg>'), ''))")
+For each detected PM, confirm it resolves the target package to `>= minimal_patched_version`. Read the lockfile directly — most reliable, robust to lockfile format quirks. PyPI distribution names are case-insensitive and normalize (`_` / `-` / `.` collapse), so lower-case + replace before comparing names:
 
-     # pdm: pdm list --json + filter, OR parse pdm.lock TOML
-     PDM_VER=$(pdm list --json 2>/dev/null | jq -r '.[] | select(.name=="<pkg>") | .version')
+```bash
+PKG_NORM=$(printf '%s' '<pkg>' | tr '[:upper:]_.' '[:lower:]--' | tr -s '-')
 
-     # pipenv: parse Pipfile.lock (JSON)
-     PIPENV_VER=$(jq -r '.default["<pkg>"].version // .develop["<pkg>"].version' Pipfile.lock | sed 's/^==//')
+# poetry: parse poetry.lock (TOML)
+POETRY_VER=$(python - <<EOF
+import tomllib
+d=tomllib.load(open('poetry.lock','rb'))
+def norm(n): return n.lower().replace('_','-').replace('.','-')
+print(next((p['version'] for p in d.get('package',[]) if norm(p['name'])=='$PKG_NORM'), ''))
+EOF
+)
 
-     # pip (raw) / pip-tools: read requirements.txt directly, or check venv
-     PIP_VER=$(grep -E '^<pkg>==' requirements.txt | sed 's/^<pkg>==//' | head -1)
-     ```
+# uv: parse uv.lock (TOML)
+UV_VER=$(python - <<EOF
+import tomllib
+d=tomllib.load(open('uv.lock','rb'))
+def norm(n): return n.lower().replace('_','-').replace('.','-')
+print(next((p['version'] for p in d.get('package',[]) if norm(p['name'])=='$PKG_NORM'), ''))
+EOF
+)
 
-     Then collect non-empty versions, sort -u, abort PR if count > 1.
+# pdm: parse pdm.lock (TOML, same shape as uv.lock)
+PDM_VER=$(python - <<EOF
+import tomllib
+d=tomllib.load(open('pdm.lock','rb'))
+def norm(n): return n.lower().replace('_','-').replace('.','-')
+print(next((p['version'] for p in d.get('package',[]) if norm(p['name'])=='$PKG_NORM'), ''))
+EOF
+)
+# Alternative: pdm list --json | jq
 
-     Special case for raw pip/pip-tools: a `requirements.txt` with `<pkg>>=X.Y.Z`
-     (not pinned exactly) is NOT a lockfile — re-resolves on every `pip install`.
-     Parity check needs version-pinning verification, not just file presence.
+# pipenv: parse Pipfile.lock (JSON, version pinned with leading "==")
+PIPENV_VER=$(jq -r --arg p '<pkg>' \
+  '(.default[$p].version // .develop[$p].version // "")' Pipfile.lock \
+  | sed -E 's/^==//')
 
-     Hash-pinned requirements (`--require-hashes`): after the bump, regenerate hashes
-     via `pip-compile --generate-hashes`. Forgetting breaks CI silently in dev,
-     loudly in prod. -->
+# pip (raw) / pip-tools: read requirements.txt — only meaningful if pinned exactly
+PIP_VER=$(grep -iE '^<pkg>==' requirements.txt 2>/dev/null \
+  | head -1 | sed -E 's/^[^=]+==//; s/[[:space:];].*$//')
+
+echo "poetry=$POETRY_VER uv=$UV_VER pdm=$PDM_VER pipenv=$PIPENV_VER pip=$PIP_VER"
+```
+
+Use only the variables for PMs actually in play; ignore the rest. All values must show the patched version (or higher).
+
+> **Note: a `requirements.txt` with `<pkg>>=X.Y.Z` (no exact `==`) is NOT a lockfile** — it re-resolves on every `pip install`. The parity check needs a pinned-exact value to be meaningful. If the project's `requirements.txt` uses `>=` ranges, treat that PM as having no committed lockfile and generate a temp resolution for the parity check (see next subsection).
+
+### Generating a temp lockfile (PMs without a committed lockfile)
+
+When CI uses a PM that has no committed lockfile (e.g. poetry-local + raw-pip-CI), generate a temp lockfile *just for the parity check*, then **delete it before commit**:
+
+| PM | Lockfile-only regen | Resulting file |
+|---|---|---|
+| poetry | `poetry lock --no-update` | `poetry.lock` |
+| uv | `uv lock` | `uv.lock` |
+| pdm | `pdm lock --no-sync` | `pdm.lock` |
+| pipenv | `pipenv lock` | `Pipfile.lock` |
+| pip-tools | `pip-compile requirements.in` (add `--generate-hashes` if hashed) | `requirements.txt` |
+| pip (raw) | `python -m pip install '<pkg>>=X.Y.Z' --dry-run --report /tmp/pip-resolve.json --quiet`, then `jq '.install[] | select(.metadata.name=="<pkg>") | .metadata.version' /tmp/pip-resolve.json` | (JSON report only, no file commit) |
+
+> ⚠ Do **NOT** commit a generated lockfile from a PM that doesn't already have one committed. Dual-lockfile drift is exactly the bug class this skill exists to prevent — a generated `requirements.txt` alongside an authoritative `poetry.lock` will silently diverge on the next regen and you've doubled the surface area, not halved it.
+
+When no lockfile is committed for a detected CI PM, also explicitly assert:
+
+- The override field for that PM is present in the manifest (see PM table in "Override pattern → Dual-write is MANDATORY").
+- The direct-dep range for the target package (if it's a direct dep) is consistent with the override.
+
+### 2. Lockfile parity (MANDATORY — abort PR on mismatch)
+
+```bash
+# Collect non-empty resolved versions across all detected PMs
+VERS=$(printf '%s\n' "$POETRY_VER" "$UV_VER" "$PDM_VER" "$PIPENV_VER" "$PIP_VER" \
+  | grep -v '^$' | sort -u)
+COUNT=$(echo "$VERS" | grep -c .)
+
+if [ "$COUNT" -eq 0 ]; then
+  echo "PARITY ABORT: could not resolve <pkg> in any lockfile"
+  exit 1
+fi
+if [ "$COUNT" -gt 1 ]; then
+  echo "PARITY ABORT: PMs disagree:"
+  echo "$VERS"
+  exit 1
+fi
+echo "PARITY OK: all PMs resolved <pkg>@$VERS"
+```
+
+If any pair of PMs resolves to different versions of the target package, **abort the PR**. Do NOT push, do NOT open the PR, do NOT commit a half-fixed state. Surface the mismatch to the user, with all versions and the likely cause:
+
+- Override missing from one of the PMs (most common — e.g. `[tool.uv] override-dependencies` written but `[tool.pdm.resolution] overrides` forgotten).
+- Poetry resolved the bump but the exported `requirements.txt` is stale — re-run `poetry export -o requirements.txt --without-hashes` (or with hashes if the project uses them).
+- `pip-tools` `requirements.txt` not regenerated after `requirements.in` edit — re-run `pip-compile`.
+- Hash-pinned `requirements.txt` left with stale hashes after a bump (will manifest as a `pip install --require-hashes` failure in CI, not as a version mismatch — regenerate hashes via `pip-compile --generate-hashes`).
+- `requires_python` skew — one PM's resolver picked an older version because the target's Python floor exceeds that PM's configured Python.
+
+Environment drift between dev and CI/CD (any PM pair: poetry-local + pip-CI, uv-local + pdm-CI, pipenv-local + raw-pip-CI, etc.) is the bug class this skill exists to prevent. The Parity Check is non-negotiable.
+
+### Don't trust install stdout
+
+`poetry lock --no-update` may print `No changes` even when the override forced a re-resolution and the lockfile actually changed. Same for `uv lock`, `pdm lock`, `pipenv lock` in some edge cases. ALWAYS run the verify commands above — they read the lockfile directly.
 
 ## Commit/PR format
 
@@ -452,14 +613,8 @@ If API confirms fix but UI still shows old count, reassure the user — it's UI 
 
 ## Platform notes
 
-<!-- TODO(py): Python-specific platform notes.
-     - **Native-wheel risk**: bumps of compiled packages (cryptography, lxml, numpy,
-       pandas, pillow, psycopg2, cffi, bcrypt, pyodbc, pyarrow) need platform-specific
-       wheel re-resolve. Check PyPI .releases[<ver>] filename list for manylinux /
-       musllinux / macosx / win_amd64 wheels matching every deploy target before
-       pinning. Patched version may drop a platform wheel → silent CI break.
-     - **Hash mismatches**: when dev and CI use different index URLs (private PyPI mirror,
-       devpi), hash-pinned requirements can fail with "hash mismatch" — same file,
-       different mirror's hash. Surface this if hash check fails.
-     - **requires_python skew**: bumping to a version with a higher Python floor than
-       the project supports breaks install on older Python deploys. -->
+- **Native-wheel risk**: bumps of compiled packages (`cryptography`, `lxml`, `numpy`, `pandas`, `pillow`, `psycopg2`, `cffi`, `bcrypt`, `pyodbc`, `pyarrow`, `grpcio`) can drop a platform wheel between versions. Verify wheels exist for every deploy-target platform tag (`manylinux2014_x86_64`, `manylinux2014_aarch64`, `musllinux_*`, `macosx_*`, `win_amd64`) AND every Python version (`cp310`, `cp311`, `cp312`) in the project's matrix before pinning. A missing wheel forces a source build on that target — silent CI break (slow build, may fail without compiler/headers).
+- **Hash mismatches**: when dev and CI use different index URLs (private PyPI mirror, devpi), hash-pinned requirements can fail with `hash mismatch` — same file, different mirror's hash. Surface this if a hash check fails on a bump that otherwise looks correct.
+- **`requires_python` skew**: bumping to a target whose `requires_python` floor exceeds the project's configured floor (`project.requires-python` / `tool.poetry.dependencies.python`) breaks install on older Python deploys. Check the target's `requires_python` via PyPI metadata before pinning.
+- **Distribution-name normalization**: PyPI normalizes `_` / `-` / `.` and case in distribution names. `pkg_a`, `pkg-a`, `Pkg.A` all refer to the same distribution at resolve time, but lockfile entries may use any of these spellings. When parsing lockfiles, normalize both sides (`.lower().replace('_','-').replace('.','-')`) before comparing names.
+- **Conda environments**: if the project also ships a `conda` env (`environment.yml` or `conda-lock.yml`), the conda channel may carry a different version of the package than PyPI. Out of scope for this skill — flag to user but don't try to fix.

--- a/skills/dependabot-triage-py/SKILL.md
+++ b/skills/dependabot-triage-py/SKILL.md
@@ -372,14 +372,29 @@ Assumes "Detect package managers in play" (workflow step 1) is already done — 
 
 1. **Dedupe**: GitHub raises one alert per committed manifest/lockfile. A repo with both `requirements.txt` AND `pyproject.toml` may raise two alerts for the same vuln. Fix the package once; cover every PM in the override.
 2. **Get advisory**: `gh api repos/<org>/<repo>/dependabot/alerts/<n>` — extract `first_patched_version`, `vulnerable_version_range`, and `cvss.score`. The list endpoint hides these. For clusters, fetch every alert in the cluster. Python advisories may have a GHSA identifier only (no CVE) — accept GHSA-prefix advisories the same way.
-3. **Locate**: direct dep (in `pyproject.toml` / `requirements*.in` / `Pipfile [packages]`) or transitive? Parse the relevant lockfile:
+3. **Locate**: direct dep (in `pyproject.toml` / `requirements*.in` / `Pipfile [packages]`) or transitive? Parse the relevant lockfile.
+
+   > **`tomllib` requires Python ≥ 3.11.** For 3.10, `pip install tomli` and replace `import tomllib` with `import tomli as tomllib` (or use a try/except shim). The top-level `[[package]]` array key is the same across poetry / uv / pdm lockfiles, but each PM's *inner* `dependencies` field has a **different shape** — separate snippets per PM:
+
    ```bash
-   # poetry.lock — TOML; dependents of <pkg>
+   # poetry.lock — [package.dependencies] is a TOML TABLE (dict)
+   #   dep_name = "version-spec"  OR  dep_name = { version = "...", ... }
    python -c "import tomllib; d=tomllib.load(open('poetry.lock','rb')); \
-     print([(p['name'], p['version']) for p in d['package'] \
+     print([(p['name'], p['version']) for p in d.get('package',[]) \
             if '<pkg>' in (p.get('dependencies') or {})])"
 
-   # uv.lock / pdm.lock — same TOML shape (key is `package`)
+   # uv.lock — package.dependencies is a LIST of inline tables with .name
+   #   dependencies = [{ name = "foo" }, { name = "bar", marker = "..." }]
+   python -c "import tomllib; d=tomllib.load(open('uv.lock','rb')); \
+     print([(p['name'], p['version']) for p in d.get('package',[]) \
+            if any(dep.get('name')=='<pkg>' for dep in (p.get('dependencies') or []))])"
+
+   # pdm.lock — package.dependencies is a LIST of PEP 508 requirement STRINGS
+   #   dependencies = ['foo>=1.0', 'bar; python_version >= "3.10"']
+   python -c "import tomllib, re; d=tomllib.load(open('pdm.lock','rb')); \
+     print([(p['name'], p['version']) for p in d.get('package',[]) \
+            if any(re.match(r'^<pkg>(?:[<>=!~\[\(;\s]|$)', s) \
+                   for s in (p.get('dependencies') or []))])"
 
    # Pipfile.lock — JSON
    jq '(.default + .develop) | to_entries[]
@@ -429,10 +444,17 @@ Assumes "Detect package managers in play" (workflow step 1) is already done — 
    #    Strip trailing .git separately — repo names can contain dots
    #    (org/foo.bar is valid), so the second path segment is [^/]+, not [^/.]+.
    PKG_REPO=$(curl -s "https://pypi.org/pypi/<pkg>/json" \
-     | jq -r '.info.project_urls.Source // .info.project_urls.Repository // .info.project_urls.Homepage // .info.home_page' \
+     | jq -r '.info.project_urls.Source // .info.project_urls.Repository // .info.project_urls.Homepage // .info.home_page // empty' \
      | sed -E 's|.*github\.com/([^/]+/[^/]+).*|\1|; s|\.git$||')
-   gh release view "v<target>" --repo "$PKG_REPO" --json tagName,body,createdAt 2>/dev/null \
-     || gh release view "<target>" --repo "$PKG_REPO" --json tagName,body,createdAt
+   # Guard against null / non-github URLs — jq's // null cascade can yield "null"
+   # as a literal string, and projects hosted on GitLab / Codeberg / self-hosted
+   # don't match the sed pattern. Skip the gh path cleanly in those cases.
+   if [[ -n "$PKG_REPO" && "$PKG_REPO" != "null" && "$PKG_REPO" == */* ]]; then
+     gh release view "v<target>" --repo "$PKG_REPO" --json tagName,body,createdAt 2>/dev/null \
+       || gh release view "<target>" --repo "$PKG_REPO" --json tagName,body,createdAt
+   else
+     echo "no GitHub repo found for <pkg> on PyPI — skipping gh release path; falling back to sdist changelog grep below"
+   fi
 
    # 3. Fallback: download the sdist and grep the bundled CHANGELOG.
    #    Resolve the sdist URL from the same PyPI JSON — distribution-name

--- a/skills/dependabot-triage-py/SKILL.md.tmpl
+++ b/skills/dependabot-triage-py/SKILL.md.tmpl
@@ -37,21 +37,44 @@ Installs into the right skills dir for your agent (Codex `~/.codex/skills`, Clau
 {{include _shared/fragments/workflow-overview-diagram.md}}
 
 1. **Detect package managers in play** — before fetching alerts, figure out which PM(s) actually touch this repo, in *every* context (local install, CI install, container build). The override + parity matrix below depends on this.
-   - **Committed manifests / lockfiles**:
+   - **Committed manifests / lockfiles** — start at repo root, then walk subdirectories for monorepo / multi-Lambda / multi-service layouts:
      ```bash
+     # Root + common manifest types
      ls requirements*.txt requirements*.in pyproject.toml Pipfile Pipfile.lock \
         poetry.lock uv.lock pdm.lock constraints*.txt 2>/dev/null
+
+     # Recursive — multi-package repos (Lambda monorepos, CDK / Serverless,
+     # multi-service workspaces). Excludes vendored / cache dirs.
+     find . \( -name 'requirements*.txt' -o -name 'requirements*.in' \
+              -o -name 'pyproject.toml' -o -name 'Pipfile' \
+              -o -name 'Pipfile.lock' -o -name 'poetry.lock' \
+              -o -name 'uv.lock' -o -name 'pdm.lock' \
+              -o -name 'constraints*.txt' \) \
+       -not -path '*/node_modules/*' -not -path '*/\.venv/*' \
+       -not -path '*/venv/*' -not -path '*/__pycache__/*' \
+       -not -path '*/\.git/*' -not -path '*/\.serverless/*' \
+       -not -path '*/build/*' -not -path '*/dist/*' 2>/dev/null | sort
      ```
+     Dependabot raises one alert per committed manifest, so the same package vulnerable in 3 per-Lambda `requirements.txt` files surfaces as 3 alerts. Per the "Same package in multiple manifests" rule in the branching strategy, the default fix is **one PR touching every affected manifest**.
    - **`pyproject.toml` PM tables** — a single `pyproject.toml` may carry config for more than one PM. Grep for the tables to see which are in play:
      ```bash
      rg -n '^\[(tool\.(poetry|pdm|uv)|project|build-system)\]' pyproject.toml 2>/dev/null
      ```
-   - **CI / container install commands** — grep CI configs and Dockerfiles for the actual install command:
+   - **CI / container / framework install commands** — grep CI configs, Dockerfiles, AND Python-deploy framework manifests for the actual install command. Lambda repos especially deploy pip *implicitly* through a framework plugin, not an explicit `pip install` line:
      ```bash
      rg -tg '*.yml' -tg '*.yaml' \
        '\b(pip (install|sync)|poetry (install|lock|sync)|uv (sync|pip|lock)|pdm (install|sync|lock)|pipenv (install|sync|lock)|pip-compile)\b' \
-       .github .gitlab-ci.yml Dockerfile* docker-compose*.yml circle.yml .circleci 2>/dev/null
+       .github .gitlab-ci.yml Dockerfile* docker-compose*.yml circle.yml .circleci \
+       serverless.yml serverless.yaml template.yaml template.yml \
+       cdk.json samconfig.toml 2>/dev/null
      ```
+   - **Implicit-resolve Python frameworks** — common deploy patterns where pip is invoked by a plugin/framework, not directly. The `pip install` line won't appear in CI; the framework manifest is the real driver:
+     - **Serverless Framework** (`serverless.yml` + `serverless-python-requirements` plugin) — each Lambda function may carry its own `requirements.txt`; plugin auto-resolves on `sls deploy`. Look for `fileName:` keys pointing at `requirements*.txt` paths and per-function `package:` blocks.
+     - **AWS SAM** (`template.yaml`) — each Lambda function's `CodeUri:` directory may contain its own `requirements.txt`; `sam build` calls pip per function.
+     - **AWS CDK** (`cdk.json` + `app.py`) — Python Lambdas built via the `PythonFunction` construct or Docker bundling; per-construct `requirements.txt` resolved at synth/deploy time.
+     - **Zappa** (`zappa_settings.json`) — single-project pip deploy.
+
+     These patterns hide the per-Lambda manifest split behind the framework. The recursive `find` above will surface every `requirements*.txt`; cross-reference each with the deploy manifest to figure out which Lambda owns it.
    - **Compare** committed manifests against CI install commands. If CI uses a different PM than the committed lockfile (e.g. `poetry.lock` committed but the Dockerfile runs `pip install -r requirements.txt`), expand the override + parity matrix accordingly (see "Override pattern" and "Verify (Parity Check)").
    - **Hash-pinned requirements flag** — if any `requirements*.txt` contains `--hash=sha256:` lines, this is a `pip-tools --generate-hashes` setup. Bumps require regenerating hashes; forgetting will break `pip install --require-hashes` in CI/prod.
    - **Don't ask the user up-front to classify the PM setup.** They often only know half the picture (their local context, not CI; or vice versa). Detect from manifest/lockfile + CI grep, show what was found, and ask only to confirm anomalies (e.g. *"I see `poetry.lock` committed but the Dockerfile runs `pip install -r requirements.txt` — confirm both are intentional?"*).

--- a/skills/dependabot-triage-py/SKILL.md.tmpl
+++ b/skills/dependabot-triage-py/SKILL.md.tmpl
@@ -177,14 +177,29 @@ The user reads the surface and decides whether the bump is worth the risk — Cl
 
 1. **Dedupe**: GitHub raises one alert per committed manifest/lockfile. A repo with both `requirements.txt` AND `pyproject.toml` may raise two alerts for the same vuln. Fix the package once; cover every PM in the override.
 2. **Get advisory**: `gh api repos/<org>/<repo>/dependabot/alerts/<n>` — extract `first_patched_version`, `vulnerable_version_range`, and `cvss.score`. The list endpoint hides these. For clusters, fetch every alert in the cluster. Python advisories may have a GHSA identifier only (no CVE) — accept GHSA-prefix advisories the same way.
-3. **Locate**: direct dep (in `pyproject.toml` / `requirements*.in` / `Pipfile [packages]`) or transitive? Parse the relevant lockfile:
+3. **Locate**: direct dep (in `pyproject.toml` / `requirements*.in` / `Pipfile [packages]`) or transitive? Parse the relevant lockfile.
+
+   > **`tomllib` requires Python ≥ 3.11.** For 3.10, `pip install tomli` and replace `import tomllib` with `import tomli as tomllib` (or use a try/except shim). The top-level `[[package]]` array key is the same across poetry / uv / pdm lockfiles, but each PM's *inner* `dependencies` field has a **different shape** — separate snippets per PM:
+
    ```bash
-   # poetry.lock — TOML; dependents of <pkg>
+   # poetry.lock — [package.dependencies] is a TOML TABLE (dict)
+   #   dep_name = "version-spec"  OR  dep_name = { version = "...", ... }
    python -c "import tomllib; d=tomllib.load(open('poetry.lock','rb')); \
-     print([(p['name'], p['version']) for p in d['package'] \
+     print([(p['name'], p['version']) for p in d.get('package',[]) \
             if '<pkg>' in (p.get('dependencies') or {})])"
 
-   # uv.lock / pdm.lock — same TOML shape (key is `package`)
+   # uv.lock — package.dependencies is a LIST of inline tables with .name
+   #   dependencies = [{ name = "foo" }, { name = "bar", marker = "..." }]
+   python -c "import tomllib; d=tomllib.load(open('uv.lock','rb')); \
+     print([(p['name'], p['version']) for p in d.get('package',[]) \
+            if any(dep.get('name')=='<pkg>' for dep in (p.get('dependencies') or []))])"
+
+   # pdm.lock — package.dependencies is a LIST of PEP 508 requirement STRINGS
+   #   dependencies = ['foo>=1.0', 'bar; python_version >= "3.10"']
+   python -c "import tomllib, re; d=tomllib.load(open('pdm.lock','rb')); \
+     print([(p['name'], p['version']) for p in d.get('package',[]) \
+            if any(re.match(r'^<pkg>(?:[<>=!~\[\(;\s]|$)', s) \
+                   for s in (p.get('dependencies') or []))])"
 
    # Pipfile.lock — JSON
    jq '(.default + .develop) | to_entries[]
@@ -234,10 +249,17 @@ The user reads the surface and decides whether the bump is worth the risk — Cl
    #    Strip trailing .git separately — repo names can contain dots
    #    (org/foo.bar is valid), so the second path segment is [^/]+, not [^/.]+.
    PKG_REPO=$(curl -s "https://pypi.org/pypi/<pkg>/json" \
-     | jq -r '.info.project_urls.Source // .info.project_urls.Repository // .info.project_urls.Homepage // .info.home_page' \
+     | jq -r '.info.project_urls.Source // .info.project_urls.Repository // .info.project_urls.Homepage // .info.home_page // empty' \
      | sed -E 's|.*github\.com/([^/]+/[^/]+).*|\1|; s|\.git$||')
-   gh release view "v<target>" --repo "$PKG_REPO" --json tagName,body,createdAt 2>/dev/null \
-     || gh release view "<target>" --repo "$PKG_REPO" --json tagName,body,createdAt
+   # Guard against null / non-github URLs — jq's // null cascade can yield "null"
+   # as a literal string, and projects hosted on GitLab / Codeberg / self-hosted
+   # don't match the sed pattern. Skip the gh path cleanly in those cases.
+   if [[ -n "$PKG_REPO" && "$PKG_REPO" != "null" && "$PKG_REPO" == */* ]]; then
+     gh release view "v<target>" --repo "$PKG_REPO" --json tagName,body,createdAt 2>/dev/null \
+       || gh release view "<target>" --repo "$PKG_REPO" --json tagName,body,createdAt
+   else
+     echo "no GitHub repo found for <pkg> on PyPI — skipping gh release path; falling back to sdist changelog grep below"
+   fi
 
    # 3. Fallback: download the sdist and grep the bundled CHANGELOG.
    #    Resolve the sdist URL from the same PyPI JSON — distribution-name

--- a/skills/dependabot-triage-py/SKILL.md.tmpl
+++ b/skills/dependabot-triage-py/SKILL.md.tmpl
@@ -182,9 +182,13 @@ The user reads the surface and decides whether the bump is worth the risk — Cl
    - **Verify the target isn't yanked**:
      ```bash
      curl -s "https://pypi.org/pypi/<pkg>/json" \
-       | jq -r '.releases["<target>"][0] | "yanked=\(.yanked) reason=\(.yanked_reason)"'
-     # → "yanked=false reason=null" expected. "yanked=true ..." → pick the next release up.
+       | jq -r --arg t '<target>' \
+           '{yanked: (.releases[$t] | map(.yanked) | any),
+             reasons: (.releases[$t] | map(.yanked_reason) | unique - [null])}'
+     # → {"yanked": false, "reasons": []} expected.
+     # → any file in the release yanked → pick the next release up.
      ```
+     Per-file yanked status *should* be consistent across a release's artifacts, but isn't guaranteed; the `any` form catches the inconsistent case too.
    - **Verify `requires_python` compatibility**:
      ```bash
      curl -s "https://pypi.org/pypi/<pkg>/<target>/json" | jq -r '.info.requires_python'
@@ -195,7 +199,7 @@ The user reads the surface and decides whether the bump is worth the risk — Cl
      curl -s "https://pypi.org/pypi/<pkg>/<target>/json" \
        | jq -r '.urls[].filename' | grep -E '\.whl$' | sort
      ```
-     Verify wheels exist for every target platform tag (`manylinux2014_x86_64`, `manylinux2014_aarch64`, `musllinux_*`, `macosx_*`, `win_amd64`) AND every Python version (`cp310`, `cp311`, `cp312`) in the project's matrix. A missing wheel forces a source build on that target — silent CI break (slow build, may fail without compiler/headers).
+     Verify wheels exist for every target platform tag (`manylinux2014_x86_64`, `manylinux2014_aarch64`, `musllinux_*`, `macosx_*`, `win_amd64`) AND every Python version in the project's `requires-python` matrix (read from `project.requires-python` in `pyproject.toml`, or the project's CI test matrix). A missing wheel forces a source build on that target — silent CI break (slow build, may fail without compiler/headers).
    - **Do NOT default to "latest in same major."** Latest maximizes change surface and risks breaking transitives. Only override the defensive minimum when (a) the user explicitly asks, or (b) the minimum is unmaintained / yanked / pulls in its own fresh CVEs.
    - Cap at the same major as currently installed unless the user approves a major bump.
 6. **Changelog scrape** — fetch release notes between current and target version. Try PyPI's project metadata first, then the upstream GitHub:
@@ -203,18 +207,31 @@ The user reads the surface and decides whether the bump is worth the risk — Cl
    # 1. Pull PyPI project URLs — Changelog / Release notes are commonly listed
    curl -s "https://pypi.org/pypi/<pkg>/json" | jq -r '.info.project_urls'
 
-   # 2. If a GitHub repo is listed, fetch release notes via gh
+   # 2. If a GitHub repo is listed, fetch release notes via gh.
+   #    Strip trailing .git separately — repo names can contain dots
+   #    (org/foo.bar is valid), so the second path segment is [^/]+, not [^/.]+.
    PKG_REPO=$(curl -s "https://pypi.org/pypi/<pkg>/json" \
      | jq -r '.info.project_urls.Source // .info.project_urls.Repository // .info.project_urls.Homepage // .info.home_page' \
-     | sed -E 's|.*github\.com/([^/]+/[^/.]+).*|\1|')
+     | sed -E 's|.*github\.com/([^/]+/[^/]+).*|\1|; s|\.git$||')
    gh release view "v<target>" --repo "$PKG_REPO" --json tagName,body,createdAt 2>/dev/null \
      || gh release view "<target>" --repo "$PKG_REPO" --json tagName,body,createdAt
 
-   # 3. Fallback: download the sdist and grep the bundled CHANGELOG
-   pip download <pkg>==<target> --no-deps --no-binary=:all: -d /tmp/<pkg>-src/ >/dev/null 2>&1
-   tar -xf /tmp/<pkg>-src/<pkg>-<target>.tar.gz -C /tmp/<pkg>-src/
-   grep -inE 'BREAKING|DEPRECATED|MIGRATION|removed|drop(ped)? support' \
-     /tmp/<pkg>-src/<pkg>-<target>/{CHANGELOG*,CHANGES*,HISTORY*,NEWS*} 2>/dev/null | head -50
+   # 3. Fallback: download the sdist and grep the bundled CHANGELOG.
+   #    Resolve the sdist URL from the same PyPI JSON — distribution-name
+   #    normalization (PyYAML → pyyaml, python-dateutil → python_dateutil)
+   #    makes hand-guessed filenames unreliable.
+   SDIST_URL=$(curl -s "https://pypi.org/pypi/<pkg>/<target>/json" \
+     | jq -r '.urls[] | select(.packagetype=="sdist") | .url' | head -1)
+   if [[ -n "$SDIST_URL" ]]; then
+     SRC=/tmp/<pkg>-<target>
+     mkdir -p "$SRC" && curl -sL "$SDIST_URL" -o "$SRC/sdist.tar.gz"
+     tar -xf "$SRC/sdist.tar.gz" -C "$SRC" --strip-components=1
+     grep -inrE 'BREAKING|DEPRECATED|MIGRATION|removed|drop(ped)? support' \
+       --include='CHANGELOG*' --include='CHANGES*' \
+       --include='HISTORY*' --include='NEWS*' "$SRC" 2>/dev/null | head -50
+   else
+     echo "no sdist published for <pkg>==<target> — wheel-only release; skip sdist changelog fallback"
+   fi
    ```
    Surface the flagged lines verbatim to the user — do not paraphrase. If `BREAKING` / `DEPRECATED` / `MIGRATION` appears, raise the safety interlock to "second confirmation required" before proceeding.
 
@@ -284,7 +301,7 @@ Dropping the marker silently widens install scope (the dep installs on platforms
   - **No universal `^`.** The semver caret is poetry-only — `^X.Y.Z` works in `[tool.poetry.dependencies]`, nowhere else. Use the explicit `>=X.Y.Z,<(X+1).0.0` form for portability across uv / pdm / pip / pipenv.
   - **PEP 440 `~=X.Y.Z`** ("compatible release") is *narrower* than the semver caret: `~=X.Y.Z` means `>=X.Y.Z,<X.(Y+1).0`, i.e. patch-only flexibility. Use only when minor-bump flexibility is unwanted.
   - **Exact pin `==X.Y.Z`** is common in `requirements.txt` for reproducibility. Surface the trade-off to the user (no patch-level updates ride in) before defaulting to exact pin. A hash-pinned `requirements.txt` already has reproducibility via `--require-hashes`; layering `==` on top is redundant unless the project explicitly forbids re-resolves.
-- **For `uv override-dependencies` and `pdm overrides`**, use the full PEP 440 specifier (`<pkg>>=X.Y.Z,<(X+1).0.0`). Bare `<pkg>` or unbounded `>=X.Y.Z` is rejected by the resolver.
+- **For `uv override-dependencies` and `pdm overrides`**, use the full PEP 440 specifier with an upper bound (`<pkg>>=X.Y.Z,<(X+1).0.0`). A bare distribution name with no version part is invalid; an unbounded `>=X.Y.Z` *is* accepted by uv but lets a future major bump ride in silently — same anti-pattern as JS bare `>=` without a caret. Always cap.
 - **Never bare `>=X.Y.Z`** without an upper bound — surprise major bumps. Always cap.
 - **Never `>X.Y.Z`** — excludes the patched version itself, forces `X.Y.Z+1`, no benefit.
 - **Pre-release versions** (`1.0.0a1`, `.rc1`, `.dev1`) are excluded by pip's default resolver unless `--pre` is passed or an exact `==` pin is used. If the only patched version is a pre-release, flag this explicitly — the project may need to opt in to pre-releases or wait for the stable.
@@ -356,7 +373,7 @@ When CI uses a PM that has no committed lockfile (e.g. poetry-local + raw-pip-CI
 | pdm | `pdm lock --no-sync` | `pdm.lock` |
 | pipenv | `pipenv lock` | `Pipfile.lock` |
 | pip-tools | `pip-compile requirements.in` (add `--generate-hashes` if hashed) | `requirements.txt` |
-| pip (raw) | `python -m pip install '<pkg>>=X.Y.Z' --dry-run --report /tmp/pip-resolve.json --quiet`, then `jq '.install[] | select(.metadata.name=="<pkg>") | .metadata.version' /tmp/pip-resolve.json` | (JSON report only, no file commit) |
+| pip (raw) | `python -m pip install '<pkg>>=X.Y.Z' --dry-run --report /tmp/pip-resolve.json --quiet`, then `jq '.install[] | select(.metadata.name=="<pkg>") | .metadata.version' /tmp/pip-resolve.json` — **requires pip ≥ 23.2** (the `--report` JSON format landed in 23.2). Verify with `pip --version` first; older pip silently produces no report. | (JSON report only, no file commit) |
 
 > ⚠ Do **NOT** commit a generated lockfile from a PM that doesn't already have one committed. Dual-lockfile drift is exactly the bug class this skill exists to prevent — a generated `requirements.txt` alongside an authoritative `poetry.lock` will silently diverge on the next regen and you've doubled the surface area, not halved it.
 
@@ -405,7 +422,7 @@ Environment drift between dev and CI/CD (any PM pair: poetry-local + pip-CI, uv-
 
 ## Platform notes
 
-- **Native-wheel risk**: bumps of compiled packages (`cryptography`, `lxml`, `numpy`, `pandas`, `pillow`, `psycopg2`, `cffi`, `bcrypt`, `pyodbc`, `pyarrow`, `grpcio`) can drop a platform wheel between versions. Verify wheels exist for every deploy-target platform tag (`manylinux2014_x86_64`, `manylinux2014_aarch64`, `musllinux_*`, `macosx_*`, `win_amd64`) AND every Python version (`cp310`, `cp311`, `cp312`) in the project's matrix before pinning. A missing wheel forces a source build on that target — silent CI break (slow build, may fail without compiler/headers).
+- **Native-wheel risk**: bumps of compiled packages (`cryptography`, `lxml`, `numpy`, `pandas`, `pillow`, `psycopg2`, `cffi`, `bcrypt`, `pyodbc`, `pyarrow`, `grpcio`) can drop a platform wheel between versions. Verify wheels exist for every deploy-target platform tag (`manylinux2014_x86_64`, `manylinux2014_aarch64`, `musllinux_*`, `macosx_*`, `win_amd64`) AND every Python version in the project's `requires-python` matrix (read from `project.requires-python` in `pyproject.toml`, or the project's CI test matrix) before pinning. A missing wheel forces a source build on that target — silent CI break (slow build, may fail without compiler/headers).
 - **Hash mismatches**: when dev and CI use different index URLs (private PyPI mirror, devpi), hash-pinned requirements can fail with `hash mismatch` — same file, different mirror's hash. Surface this if a hash check fails on a bump that otherwise looks correct.
 - **`requires_python` skew**: bumping to a target whose `requires_python` floor exceeds the project's configured floor (`project.requires-python` / `tool.poetry.dependencies.python`) breaks install on older Python deploys. Check the target's `requires_python` via PyPI metadata before pinning.
 - **Distribution-name normalization**: PyPI normalizes `_` / `-` / `.` and case in distribution names. `pkg_a`, `pkg-a`, `Pkg.A` all refer to the same distribution at resolve time, but lockfile entries may use any of these spellings. When parsing lockfiles, normalize both sides (`.lower().replace('_','-').replace('.','-')`) before comparing names.

--- a/skills/dependabot-triage-py/SKILL.md.tmpl
+++ b/skills/dependabot-triage-py/SKILL.md.tmpl
@@ -1,11 +1,9 @@
 ---
 name: dependabot-triage-py
-description: '[scaffold — Python-specific blocks pending] Triage and fix Dependabot vulnerability alerts in Python repos (pip, poetry, uv, pdm, pipenv). v2.1 workflow with Standard (defensive) and Fast-Track (low-risk) modes — defensive minimal-patched versioning (PEP 440 ranges), exposure mapping (Public/API · Internal/Dev), CI workflow inspection, mandatory lockfile parity check across every PM that touches pyproject.toml / requirements*.txt, changelog scrape with BREAKING/DEPRECATED/MIGRATION flagging, and safety interlock before applying bumps. Fast-Track mode skips changelog + detailed exposure for Internal/Dev or CVSS<7 alerts, but parity check + dual-write are non-negotiable. Use when the user shares a Dependabot URL for a Python repo, asks to fix CVEs in a Python project, or asks which Python vulnerability to pick first.'
+description: Triage and fix Dependabot vulnerability alerts in Python repos (pip, poetry, uv, pdm, pipenv). v2.1 workflow with Standard (defensive) and Fast-Track (low-risk) modes — defensive minimal-patched versioning (PEP 440 ranges), exposure mapping (Public/API · Internal/Dev), CI workflow inspection to detect every PM in play, mandatory lockfile parity check across every PM that touches pyproject.toml / requirements*.txt, changelog scrape with BREAKING/DEPRECATED/MIGRATION flagging, and safety interlock before applying bumps. Fast-Track mode skips changelog + detailed exposure for Internal/Dev or CVSS<7 alerts, but parity check + dual-write are non-negotiable. Use when the user shares a Dependabot URL for a Python repo, asks to fix CVEs in a Python project, or asks which Python vulnerability to pick first.
 ---
 
 # Dependabot Triage & Fix — Python (v2.1)
-
-> **Scaffold — not yet feature-complete.** Shared workflow is wired in; Python-specific blocks are marked `<!-- TODO(py): ... -->` and will be fleshed out in a follow-up. Some shared examples reference JS packages (axios, dompurify) — those are illustrative; the concepts apply to Python ecosystems.
 
 {{include _shared/fragments/intro-v2-1-highlights.md}}
 
@@ -38,31 +36,32 @@ Installs into the right skills dir for your agent (Codex `~/.codex/skills`, Clau
 
 {{include _shared/fragments/workflow-overview-diagram.md}}
 
-1. **Detect package managers in play** —
-   <!-- TODO(py): full PM detection block.
-        Committed manifests/lockfiles:
-          - requirements*.txt / requirements*.in (pip / pip-tools)
-          - Pipfile + Pipfile.lock (pipenv)
-          - pyproject.toml [tool.poetry] + poetry.lock
-          - pyproject.toml [tool.pdm] + pdm.lock
-          - pyproject.toml [project] + uv.lock (uv)
-          - constraints.txt (pip constraints — referenced via `-c`)
-        CI / container install grep:
-          - pip install -r ... / pip install --constraint ...
-          - poetry install / poetry lock
-          - uv sync / uv pip compile / uv pip install
-          - pdm install / pdm sync
-          - pipenv install / pipenv sync
-          - pip-compile
-        Mirror the JS step-1 "compare committed vs CI" logic.
-        Flag hash-pinned requirements (pip-tools `--generate-hashes`) — bump
-        breaks `pip install --require-hashes` unless hashes are regenerated. -->
+1. **Detect package managers in play** — before fetching alerts, figure out which PM(s) actually touch this repo, in *every* context (local install, CI install, container build). The override + parity matrix below depends on this.
+   - **Committed manifests / lockfiles**:
+     ```bash
+     ls requirements*.txt requirements*.in pyproject.toml Pipfile Pipfile.lock \
+        poetry.lock uv.lock pdm.lock constraints*.txt 2>/dev/null
+     ```
+   - **`pyproject.toml` PM tables** — a single `pyproject.toml` may carry config for more than one PM. Grep for the tables to see which are in play:
+     ```bash
+     rg -n '^\[(tool\.(poetry|pdm|uv)|project|build-system)\]' pyproject.toml 2>/dev/null
+     ```
+   - **CI / container install commands** — grep CI configs and Dockerfiles for the actual install command:
+     ```bash
+     rg -tg '*.yml' -tg '*.yaml' \
+       '\b(pip (install|sync)|poetry (install|lock|sync)|uv (sync|pip|lock)|pdm (install|sync|lock)|pipenv (install|sync|lock)|pip-compile)\b' \
+       .github .gitlab-ci.yml Dockerfile* docker-compose*.yml circle.yml .circleci 2>/dev/null
+     ```
+   - **Compare** committed manifests against CI install commands. If CI uses a different PM than the committed lockfile (e.g. `poetry.lock` committed but the Dockerfile runs `pip install -r requirements.txt`), expand the override + parity matrix accordingly (see "Override pattern" and "Verify (Parity Check)").
+   - **Hash-pinned requirements flag** — if any `requirements*.txt` contains `--hash=sha256:` lines, this is a `pip-tools --generate-hashes` setup. Bumps require regenerating hashes; forgetting will break `pip install --require-hashes` in CI/prod.
+   - **Don't ask the user up-front to classify the PM setup.** They often only know half the picture (their local context, not CI; or vice versa). Detect from manifest/lockfile + CI grep, show what was found, and ask only to confirm anomalies (e.g. *"I see `poetry.lock` committed but the Dockerfile runs `pip install -r requirements.txt` — confirm both are intentional?"*).
 2. **Fetch alerts**:
-   <!-- TODO(py): mirror JS step 2 — filter `.dependency.package.ecosystem == "pip"`.
-        Mixed-ecosystem repos: surface non-pip alerts as out-of-scope.
-        Dependabot's pip ecosystem sometimes flags packages installed via apt/system
-        Docker base images, not pip — verify the package is actually in pip's
-        resolved tree (lockfile or `pip list`) before applying. -->
+   - Repo URL → `gh api "repos/<org>/<repo>/dependabot/alerts?state=open&per_page=100"`
+   - Org URL → only after explicit user confirmation, then `gh api "orgs/<org>/dependabot/alerts?state=open&per_page=100"` (paginates across every repo).
+   - Filter `.dependency.package.ecosystem == "pip"` for this skill; surface non-Python alerts as out-of-scope.
+   - Dedupe by `(repo, package)`.
+   - **Mixed-ecosystem repos (Python + npm, Go + Python, etc.):** group alerts by ecosystem BEFORE presenting the ranked table. Output out-of-scope ecosystems as a separate blocked section at the top — e.g. "⛔ Out of scope for this skill (handle separately): axios × 6 (npm), lodash × 2 (npm)." The user needs to see what's NOT being covered so they can act on it elsewhere. Never silently drop non-Python alerts.
+   - **System-package false positives**: Dependabot's `pip` ecosystem occasionally flags packages installed via apt / Docker base images, not pip. Before applying, verify the package actually appears in pip's resolved tree (in the lockfile or `pip list` output). If absent from pip but present in the system, the fix is a base-image bump, not a pip override.
 {{include _shared/fragments/workflow-steps-3-4-rank-and-advisory.md}}
 {{include _shared/fragments/workflow-step-5-mode-selection.md}}
 
@@ -73,23 +72,9 @@ Installs into the right skills dir for your agent (Codex `~/.codex/skills`, Clau
 ### Apply (steps 9–13) — identical in both modes, non-negotiable
 
 9. **Confirm branching strategy AND base branch.** Detect default branch via `gh repo view --json defaultBranchRef`; never hardcode `main`. Default: one PR per package off latest `origin/<detected-base>`.
-10. **Edit the manifest(s)** —
-    <!-- TODO(py): per-PM edit instructions.
-         - poetry: pin in [tool.poetry.dependencies] or [tool.poetry.group.*.dependencies]
-         - uv: [tool.uv] override-dependencies = ["pkg>=X.Y.Z"]
-         - pdm: [tool.pdm.resolution] overrides = { "pkg" = ">=X.Y.Z" }
-         - pip (raw) / pipenv: NO transitive override mechanism — must bump the
-           parent dep or use constraints.txt for pip.
-         Required in BOTH modes. Preserve environment markers and extras. -->
-11. **Regenerate every relevant lockfile** —
-    <!-- TODO(py): per-PM regen commands.
-         - poetry: poetry lock --no-update
-         - uv: uv lock
-         - pdm: pdm lock
-         - pipenv: pipenv lock
-         - pip-tools: pip-compile (with --generate-hashes if hash-pinned)
-         For PMs without a committed lockfile, generate temp + delete before commit. -->
-12. **Parity check** — for each PM detected in step 1, read its lockfile and assert every PM resolved to the *same* version of the target package. **Mismatch → abort PR in BOTH modes.**
+10. **Edit the manifest(s)** — write the override into *every* PM detected in step 1 (see "Override pattern"). Required in BOTH modes. Preserve environment markers (`; python_version >= '3.10'`) and extras (`cryptography[ssh]`) when editing.
+11. **Regenerate every relevant lockfile** — for each PM detected in step 1, run its lockfile-only regen. For PMs without a committed lockfile (e.g. raw `pip install -r` setups), regenerate a temp lockfile *just for the parity check* and **delete it before commit** (see "Verify (Parity Check)"). No "primary" lockfile.
+12. **Parity check** — for each PM detected in step 1, read its lockfile and assert every PM resolved to the *same* version of the target package. **Mismatch → abort PR in BOTH modes.** See "Verify (Parity Check)" for the commands.
 13. **Commit on the branch and open a PR** — with explicit user OK before pushing.
 
 {{include _shared/fragments/claude-will-not.md}}
@@ -102,37 +87,64 @@ Installs into the right skills dir for your agent (Codex `~/.codex/skills`, Clau
 
 ### Categories
 
-<!-- TODO(py): two-category table (Client-Bundle dropped — Python rarely ships to browser).
-     - **Public/API**: Django views.py / urls.py / middleware.py / consumers.py (ASGI),
-       Flask/FastAPI/Starlette route decorators, AIOHTTP handlers, gRPC servicers,
-       Lambda entry handlers, Celery tasks consuming external input,
-       WSGI/ASGI entrypoints (wsgi.py, asgi.py).
-     - **Internal/Dev**: setup.py, setup.cfg, pyproject.toml [build-system], conftest.py,
-       tests/, scripts/, tox.ini, noxfile.py, Makefile-driven scripts, Sphinx config.
-     Note: Streamlit / Gradio / Dash apps ship Python server-side — treat as Public/API. -->
+Two categories (the JS skill's Client-Bundle drops — Python rarely ships to a browser):
+
+| Category | Definition | Example file paths |
+|---|---|---|
+| **Public/API** | Code that serves HTTP/RPC/webhook traffic from outside the trust boundary. Attacker-controlled input flows in. | Django `views.py` / `urls.py` / `middleware.py` / `consumers.py` (ASGI), FastAPI / Flask / Starlette route decorators, AIOHTTP handlers, gRPC servicers, Lambda entry handlers, Celery tasks consuming external input, `wsgi.py` / `asgi.py` entrypoints |
+| **Internal/Dev** | Build, tooling, scripts, tests, configs. Does NOT run in prod request path. | `setup.py`, `setup.cfg`, `pyproject.toml [build-system]`, `conftest.py`, `tests/`, `scripts/`, `tox.ini`, `noxfile.py`, Sphinx config, Makefile-driven scripts |
+
+> Streamlit / Gradio / Dash apps ship Python server-side — treat as Public/API. PyScript / Brython are rare Python-in-browser cases; if encountered, route through the JS skill's Client-Bundle lens.
 
 ### How to enumerate import sites
 
-<!-- TODO(py): enumeration commands.
-     Key gotcha: PyPI distribution name != Python import name often.
-     Examples: PyYAML/yaml, Pillow/PIL, opencv-python/cv2, scikit-learn/sklearn,
-     beautifulsoup4/bs4, python-dateutil/dateutil.
+PyPI distribution name does NOT always match the Python import name. Common mismatches:
 
-     Resolve dist→import via:
-       python -c "from importlib.metadata import packages_distributions; \
-         print({m: d for m, d in packages_distributions().items() if '<dist>' in d})"
-     (Requires Python 3.10+; use `importlib_metadata` backport for 3.8/3.9.)
+| PyPI distribution | Python import |
+|---|---|
+| `PyYAML` | `yaml` |
+| `Pillow` | `PIL` |
+| `opencv-python` | `cv2` |
+| `scikit-learn` | `sklearn` |
+| `beautifulsoup4` | `bs4` |
+| `python-dateutil` | `dateutil` |
+| `protobuf` | `google.protobuf` |
+| `python-jose` | `jose` |
 
-     Then grep with the import name:
-       rg -t py "^(import |from ) *<import-name>([. ]|$)" -l | sort -u -->
+Resolve dist→import via `importlib.metadata.packages_distributions()` (Python 3.10+; use the `importlib_metadata` backport for 3.8/3.9):
+
+```bash
+python -c "from importlib.metadata import packages_distributions; \
+  d=packages_distributions(); \
+  print(sorted({m for m, dists in d.items() if '<dist>' in dists}))"
+```
+
+Then grep with each import name:
+
+```bash
+# Prefer ripgrep (fast, respects .gitignore)
+rg -t py "^[[:space:]]*(import|from)[[:space:]]+<import-name>([. ]|$)" -l | sort -u
+
+# Fallback to grep
+grep -rE "^[[:space:]]*(import|from)[[:space:]]+<import-name>([. ]|$)" \
+  --include='*.py' -l . | grep -v -E '/(\.venv|venv|__pycache__|\.tox|\.eggs|build|dist)/' | sort -u
+```
+
+Then bucket each path by matching against the Categories table. Paths that don't fit cleanly → ask the user, do not guess.
 
 ### How to present to the user
 
-<!-- TODO(py): adapt JS surface-summary format; drop Client-Bundle row.
-     Example output:
-       Exposure surface for requests in webhook-api:
-         Public/API     : 8 sites (e.g. app/routes/webhook.py, services/external.py, ...)
-         Internal/Dev   : 2 sites (e.g. tests/conftest.py, scripts/seed.py, ...) -->
+Output as a surface summary, not a verdict:
+
+```
+Exposure surface for requests in webhook-api:
+  Public/API     : 8 sites (e.g. app/routes/webhook.py, services/external_client.py, ...)
+  Internal/Dev   : 2 sites (e.g. tests/conftest.py, scripts/seed_data.py, ...)
+```
+
+If a single import site straddles categories (e.g. a util re-exported from both a route handler and a test helper), it inherits the highest-risk category present.
+
+The user reads the surface and decides whether the bump is worth the risk — Claude does not say "this is reachable" or "this is unreachable".
 
 {{include _shared/fragments/exposure-mapping-cross-repo.md}}
 
@@ -140,103 +152,252 @@ Installs into the right skills dir for your agent (Codex `~/.codex/skills`, Clau
 
 {{include _shared/fragments/workflow-per-alert-intro.md}}
 
-<!-- TODO(py): workflow-per-alert numbered steps 1–8.
-     1. Dedupe: GitHub raises one alert per committed lockfile.
-     2. Get advisory: same `gh api repos/.../dependabot/alerts/<n>` — extract
-        first_patched_version, vulnerable_version_range, cvss.score.
-        Note: some Python alerts have GHSA only, no CVE — accept GHSA-prefix.
-     3. Locate: parse poetry.lock / uv.lock TOML, pdm.lock, Pipfile.lock JSON,
-        or requirements.txt.
-     4. Exposure Mapping: see Categories above.
-     5. Pick version (defensive minimal-patched, PEP 440):
-        - Single alert: >=X.Y.Z,<(X+1).0.0 of first_patched_version
-        - Cluster: same shape, X.Y.Z = max(first_patched_version) across cluster
-        - Verify NOT yanked via PyPI .releases[<ver>][0].yanked
-        - Check requires_python on PyPI doesn't exceed project's python_requires
-        - Verify wheel availability for every deploy-target platform/Python combo
-     6. Changelog scrape: PyPI project_urls.Changelog / Release notes URL via
-        `curl -s https://pypi.org/pypi/<pkg>/json | jq -r '.info.project_urls'`,
-        fall back to GitHub release notes (`gh release view`).
-     7. Safety interlock — PAUSE (identical to JS).
-     8. After user OK: edit manifest(s), regen lockfile(s), run Parity Check,
-        commit, ask before push. -->
+1. **Dedupe**: GitHub raises one alert per committed manifest/lockfile. A repo with both `requirements.txt` AND `pyproject.toml` may raise two alerts for the same vuln. Fix the package once; cover every PM in the override.
+2. **Get advisory**: `gh api repos/<org>/<repo>/dependabot/alerts/<n>` — extract `first_patched_version`, `vulnerable_version_range`, and `cvss.score`. The list endpoint hides these. For clusters, fetch every alert in the cluster. Python advisories may have a GHSA identifier only (no CVE) — accept GHSA-prefix advisories the same way.
+3. **Locate**: direct dep (in `pyproject.toml` / `requirements*.in` / `Pipfile [packages]`) or transitive? Parse the relevant lockfile:
+   ```bash
+   # poetry.lock — TOML; dependents of <pkg>
+   python -c "import tomllib; d=tomllib.load(open('poetry.lock','rb')); \
+     print([(p['name'], p['version']) for p in d['package'] \
+            if '<pkg>' in (p.get('dependencies') or {})])"
+
+   # uv.lock / pdm.lock — same TOML shape (key is `package`)
+
+   # Pipfile.lock — JSON
+   jq '(.default + .develop) | to_entries[]
+       | select(.value.dependencies // {} | has("<pkg>"))
+       | {name: .key, version: .value.version}' Pipfile.lock
+   ```
+4. **Exposure Mapping**: see "Exposure Mapping" section. Categorize every import site (Public/API · Internal/Dev) and produce a surface summary for the user.
+5. **Pick version (defensive minimal-patched, PEP 440)**:
+   - Single alert: `>=X.Y.Z,<(X+1).0.0` of `first_patched_version`.
+   - Cluster: same shape, `X.Y.Z = max(first_patched_version)` across every CVE in the cluster — i.e. the *minimal* version that supersets every patch. Compute via:
+     ```bash
+     for n in <alert-numbers>; do
+       gh api repos/<org>/<repo>/dependabot/alerts/$n \
+         --jq '.security_advisory.vulnerabilities[0].first_patched_version.identifier'
+     done | python -c "import sys; from packaging.version import Version; \
+       vs=[Version(l.strip()) for l in sys.stdin if l.strip()]; print(max(vs))"
+     ```
+   - **Verify the target isn't yanked**:
+     ```bash
+     curl -s "https://pypi.org/pypi/<pkg>/json" \
+       | jq -r '.releases["<target>"][0] | "yanked=\(.yanked) reason=\(.yanked_reason)"'
+     # → "yanked=false reason=null" expected. "yanked=true ..." → pick the next release up.
+     ```
+   - **Verify `requires_python` compatibility**:
+     ```bash
+     curl -s "https://pypi.org/pypi/<pkg>/<target>/json" | jq -r '.info.requires_python'
+     ```
+     If the target's floor exceeds the project's configured floor (`project.requires-python` or `tool.poetry.dependencies.python` in `pyproject.toml`), the bump breaks install on older deploy targets. Surface to user.
+   - **Wheel availability across deploy targets** — for compiled packages (cryptography, lxml, numpy, pandas, pillow, psycopg2, cffi, bcrypt, pyarrow, grpcio), list available wheels:
+     ```bash
+     curl -s "https://pypi.org/pypi/<pkg>/<target>/json" \
+       | jq -r '.urls[].filename' | grep -E '\.whl$' | sort
+     ```
+     Verify wheels exist for every target platform tag (`manylinux2014_x86_64`, `manylinux2014_aarch64`, `musllinux_*`, `macosx_*`, `win_amd64`) AND every Python version (`cp310`, `cp311`, `cp312`) in the project's matrix. A missing wheel forces a source build on that target — silent CI break (slow build, may fail without compiler/headers).
+   - **Do NOT default to "latest in same major."** Latest maximizes change surface and risks breaking transitives. Only override the defensive minimum when (a) the user explicitly asks, or (b) the minimum is unmaintained / yanked / pulls in its own fresh CVEs.
+   - Cap at the same major as currently installed unless the user approves a major bump.
+6. **Changelog scrape** — fetch release notes between current and target version. Try PyPI's project metadata first, then the upstream GitHub:
+   ```bash
+   # 1. Pull PyPI project URLs — Changelog / Release notes are commonly listed
+   curl -s "https://pypi.org/pypi/<pkg>/json" | jq -r '.info.project_urls'
+
+   # 2. If a GitHub repo is listed, fetch release notes via gh
+   PKG_REPO=$(curl -s "https://pypi.org/pypi/<pkg>/json" \
+     | jq -r '.info.project_urls.Source // .info.project_urls.Repository // .info.project_urls.Homepage // .info.home_page' \
+     | sed -E 's|.*github\.com/([^/]+/[^/.]+).*|\1|')
+   gh release view "v<target>" --repo "$PKG_REPO" --json tagName,body,createdAt 2>/dev/null \
+     || gh release view "<target>" --repo "$PKG_REPO" --json tagName,body,createdAt
+
+   # 3. Fallback: download the sdist and grep the bundled CHANGELOG
+   pip download <pkg>==<target> --no-deps --no-binary=:all: -d /tmp/<pkg>-src/ >/dev/null 2>&1
+   tar -xf /tmp/<pkg>-src/<pkg>-<target>.tar.gz -C /tmp/<pkg>-src/
+   grep -inE 'BREAKING|DEPRECATED|MIGRATION|removed|drop(ped)? support' \
+     /tmp/<pkg>-src/<pkg>-<target>/{CHANGELOG*,CHANGES*,HISTORY*,NEWS*} 2>/dev/null | head -50
+   ```
+   Surface the flagged lines verbatim to the user — do not paraphrase. If `BREAKING` / `DEPRECATED` / `MIGRATION` appears, raise the safety interlock to "second confirmation required" before proceeding.
+
+   **Transitive-dep qualifier:** Before demanding a second confirmation, check whether the flagged package has any direct import sites in source (from the Exposure Mapping step). If zero direct imports exist — the package is purely transitive — state this explicitly alongside the flag: *"This flag appears in a package that is not directly imported by your source code. The breaking change is unlikely to affect you unless your code parses its error messages or hooks into its internals."* This collapses two confirmation rounds into one when the flag is clearly irrelevant to the calling code.
+7. **Safety interlock — PAUSE.** Print to the user:
+   - chosen target version + reason (defensive minimal vs latest, why)
+   - exposure surface (counts per category, sample paths)
+   - changelog flags (verbatim lines, or "no flags" if clean)
+   - wheel-availability check result (if the package is compiled)
+   - `requires_python` skew flag (if the target's floor exceeds the project's)
+
+   Wait for explicit go-ahead. If changelog flags were raised, require an unambiguous "yes, continue" / "I've handled it" — silence or ambiguous reply means stop.
+
+8. After user OK: edit manifest(s), regen lockfile(s), run Parity Check, commit, ask before push.
 
 ## Override pattern (Python)
 
-<!-- TODO(py): per-PM override mechanisms.
-     Dual-write semantics: write the override into EVERY PM that touches the project.
+Use overrides for:
+- **Transitive vulns** — package not in `[project.dependencies]` / `[tool.poetry.dependencies]` / `[packages]`. The override mechanism is the only fix without bumping a parent.
+- **Direct deps where transitives ALSO request the package** — bumping the direct dep doesn't guarantee transitives get the same resolved version (the resolver may pick a different one for a transitive's range). Add the override anyway as defense-in-depth.
 
-     | PM | Override field | Regen command |
-     |---|---|---|
-     | pip (raw) | NO TRANSITIVE OVERRIDE — pin in requirements.txt or use constraints.txt | `pip install -r requirements.txt -c constraints.txt` |
-     | pip-tools | `*.in` source + compiled `*.txt` (with --generate-hashes if used) | `pip-compile requirements.in` |
-     | poetry | `[tool.poetry.dependencies]` direct pin; transitive needs explicit `poetry add` | `poetry lock --no-update` |
-     | uv | `[tool.uv] override-dependencies = ["pkg>=X.Y.Z"]` | `uv lock` |
-     | pdm | `[tool.pdm.resolution] overrides = { "pkg" = ">=X.Y.Z" }` | `pdm lock` |
-     | pipenv | Edit Pipfile [packages]; NO transitive override mechanism | `pipenv lock` |
+### Dual-write is MANDATORY
 
-     CRITICAL: raw pip and pipenv have NO transitive-override mechanism. If a
-     transitive bump is required and only pip/pipenv are in play, the only fix is
-     to bump the parent dep or migrate to uv/pdm. Hard-ineligible for Fast-Track.
+Write the override field for **every PM detected in step 1**. Different PMs honor *different* mechanisms — and crucially, **raw pip and pipenv have NO transitive-override mechanism at all**:
 
-     Preserve environment markers (e.g. `; python_version >= '3.10'`) and extras
-     (e.g. `cryptography[ssh]>=42.0.0`) when overriding. -->
+| PM | Override mechanism | Regen command |
+|---|---|---|
+| pip (raw) | NO TRANSITIVE OVERRIDE — pin the package directly in `requirements.txt`, or use a `constraints.txt` referenced via `pip install -c constraints.txt` | `pip install -r requirements.txt -c constraints.txt` (no committed lockfile — temp resolve for parity check only) |
+| pip-tools | Edit `requirements.in` (or add a constraint); `pip-compile` re-resolves into `requirements.txt` | `pip-compile requirements.in` (add `--generate-hashes` if the existing file uses hashes) |
+| poetry | `[tool.poetry.dependencies]` for direct pin. For a transitive, poetry has no override *field* — `poetry add <pkg>@>=X.Y.Z,<(X+1).0.0` adds it as an explicit direct dep (the only mechanism). | `poetry lock --no-update` |
+| uv | `[tool.uv] override-dependencies = ["<pkg>>=X.Y.Z,<(X+1).0.0"]` | `uv lock` |
+| pdm | `[tool.pdm.resolution] overrides = { "<pkg>" = ">=X.Y.Z,<(X+1).0.0" }` | `pdm lock` |
+| pipenv | Edit `[packages]` in `Pipfile` for direct pin; NO transitive override mechanism | `pipenv lock` |
+
+Writing to only one when more than one PM is in play produces **environment drift**: developers see one resolved version locally, CI ships another. This is exactly the bug class this skill exists to prevent. Write the override into every relevant field with the same target range, every time, even if only one lockfile is currently committed.
+
+A common Python pattern in this org: `poetry.lock` committed for local dev + an exported `requirements.txt` consumed by the prod Docker image. Both manifests must carry the override (poetry's `[tool.poetry.dependencies]` direct pin AND the regenerated `requirements.txt` from `poetry export`).
+
+### No-transitive-override case (raw pip / pipenv only)
+
+If the only PMs in play are raw pip and/or pipenv, AND the bump is transitive (the vulnerable package is not a direct dep), there is no override mechanism available. The fix paths are:
+
+1. **Bump the parent dep** that pulls in the vulnerable transitive — if the parent's newer version has migrated to a patched range. (Often the right answer.)
+2. **Migrate to a PM with overrides** (uv or pdm) — a project-level change, out of scope for a single security PR.
+3. **Add the transitive as an explicit direct dep** with the patched pin in `requirements.txt` / `Pipfile [packages]`. Surface to the user: this changes the dep graph and may not be the right answer if the parent later drops the transitive.
+
+**Fast-Track is hard-ineligible in this case** — the no-override-mechanism constraint forces option (1) or (3), which deserve Standard's full visibility (changelog scrape + exposure surface + safety interlock).
+
+### Preserve environment markers and extras
+
+When applying the override, preserve any environment markers and extras already present on the dep:
+
+```toml
+# Before
+"<pkg>[extra1,extra2] ; python_version >= '3.10' and platform_system != 'Windows'"
+
+# After (override applied as version pin)
+"<pkg>[extra1,extra2]>=X.Y.Z,<(X+1).0.0 ; python_version >= '3.10' and platform_system != 'Windows'"
+```
+
+Dropping the marker silently widens install scope (the dep installs on platforms/Python versions it shouldn't); dropping extras silently disables feature-gated functionality.
 
 ## Version range rules
 
-<!-- TODO(py): PEP 440 semantics — NOT semver.
-     - Default to defensive minimal patched. Use `>=X.Y.Z,<(X+1).0.0` where
-       X.Y.Z is the *minimal* version that supersets every applicable CVE patch.
-       (Universal — works in poetry, uv, pdm, pipenv, pip.)
-     - Poetry-only alias: `^X.Y.Z` (caret) — same as `>=X.Y.Z,<(X+1).0.0`.
-       Don't use in non-poetry contexts; not PEP 440 standard.
-     - Never use bare `>=X.Y.Z` without an upper bound (anti-major-bump).
-     - PEP 440 `~=X.Y.Z` (compatible release) is FINER than caret: `~=X.Y.Z`
-       means `>=X.Y.Z,<X.(Y+1).0`. Use only when minor-only flexibility wanted.
-     - For uv `override-dependencies` and pdm `overrides`, use full PEP 440
-       specifier (e.g. `pkg>=X.Y.Z,<(X+1).0.0`).
-     - Exact pin `==X.Y.Z` is common in `requirements.txt` for reproducibility;
-       surface trade-off (no patch-level updates) to user before defaulting to exact pin.
-     - Pre-release versions (1.0.0a1, .rc1, .dev1) are excluded by pip default unless
-       `--pre` flag or exact `==` pin. If the only patched version is pre-release,
-       flag explicitly. -->
+- **Default to defensive minimal patched.** Use `>=X.Y.Z,<(X+1).0.0` where `X.Y.Z` is the *minimal* version that supersets every applicable CVE patch (single alert: `first_patched_version`; cluster: `max(first_patched_version)` across the cluster). Universal across pip, poetry, uv, pdm, pipenv. Latest-in-major is opt-in only — its larger change surface raises the chance the bump itself breaks something.
+- **PEP 440 ≠ semver.** Critical syntax differences:
+  - **No universal `^`.** The semver caret is poetry-only — `^X.Y.Z` works in `[tool.poetry.dependencies]`, nowhere else. Use the explicit `>=X.Y.Z,<(X+1).0.0` form for portability across uv / pdm / pip / pipenv.
+  - **PEP 440 `~=X.Y.Z`** ("compatible release") is *narrower* than the semver caret: `~=X.Y.Z` means `>=X.Y.Z,<X.(Y+1).0`, i.e. patch-only flexibility. Use only when minor-bump flexibility is unwanted.
+  - **Exact pin `==X.Y.Z`** is common in `requirements.txt` for reproducibility. Surface the trade-off to the user (no patch-level updates ride in) before defaulting to exact pin. A hash-pinned `requirements.txt` already has reproducibility via `--require-hashes`; layering `==` on top is redundant unless the project explicitly forbids re-resolves.
+- **For `uv override-dependencies` and `pdm overrides`**, use the full PEP 440 specifier (`<pkg>>=X.Y.Z,<(X+1).0.0`). Bare `<pkg>` or unbounded `>=X.Y.Z` is rejected by the resolver.
+- **Never bare `>=X.Y.Z`** without an upper bound — surprise major bumps. Always cap.
+- **Never `>X.Y.Z`** — excludes the patched version itself, forces `X.Y.Z+1`, no benefit.
+- **Pre-release versions** (`1.0.0a1`, `.rc1`, `.dev1`) are excluded by pip's default resolver unless `--pre` is passed or an exact `==` pin is used. If the only patched version is a pre-release, flag this explicitly — the project may need to opt in to pre-releases or wait for the stable.
+- If the defensive minimum is yanked, unmaintained, or itself triggers fresh CVEs, escalate to the user — present the next-newest candidate plus its changelog scrape and let the user pick.
 
 ## Verify (Parity Check)
 
-<!-- TODO(py): per-PM patched-version resolution + parity assertion.
-     For each detected PM, read the lockfile (or query the PM directly) and
-     assert it resolves the target package to >= minimal_patched_version.
+Two checks. Both must pass before the PR is opened. Run for **every PM detected in step 1**, not just one.
 
-     ```bash
-     # poetry: parse poetry.lock (TOML) for the resolved version
-     POETRY_VER=$(python -c "import tomllib; \
-       d=tomllib.load(open('poetry.lock','rb')); \
-       print(next((p['version'] for p in d['package'] if p['name']=='<pkg>'), ''))")
+### 1. Patched-version resolution
 
-     # uv: parse uv.lock (TOML)
-     UV_VER=$(python -c "import tomllib; \
-       d=tomllib.load(open('uv.lock','rb')); \
-       print(next((p['version'] for p in d.get('package',[]) if p['name']=='<pkg>'), ''))")
+For each detected PM, confirm it resolves the target package to `>= minimal_patched_version`. Read the lockfile directly — most reliable, robust to lockfile format quirks. PyPI distribution names are case-insensitive and normalize (`_` / `-` / `.` collapse), so lower-case + replace before comparing names:
 
-     # pdm: pdm list --json + filter, OR parse pdm.lock TOML
-     PDM_VER=$(pdm list --json 2>/dev/null | jq -r '.[] | select(.name=="<pkg>") | .version')
+```bash
+PKG_NORM=$(printf '%s' '<pkg>' | tr '[:upper:]_.' '[:lower:]--' | tr -s '-')
 
-     # pipenv: parse Pipfile.lock (JSON)
-     PIPENV_VER=$(jq -r '.default["<pkg>"].version // .develop["<pkg>"].version' Pipfile.lock | sed 's/^==//')
+# poetry: parse poetry.lock (TOML)
+POETRY_VER=$(python - <<EOF
+import tomllib
+d=tomllib.load(open('poetry.lock','rb'))
+def norm(n): return n.lower().replace('_','-').replace('.','-')
+print(next((p['version'] for p in d.get('package',[]) if norm(p['name'])=='$PKG_NORM'), ''))
+EOF
+)
 
-     # pip (raw) / pip-tools: read requirements.txt directly, or check venv
-     PIP_VER=$(grep -E '^<pkg>==' requirements.txt | sed 's/^<pkg>==//' | head -1)
-     ```
+# uv: parse uv.lock (TOML)
+UV_VER=$(python - <<EOF
+import tomllib
+d=tomllib.load(open('uv.lock','rb'))
+def norm(n): return n.lower().replace('_','-').replace('.','-')
+print(next((p['version'] for p in d.get('package',[]) if norm(p['name'])=='$PKG_NORM'), ''))
+EOF
+)
 
-     Then collect non-empty versions, sort -u, abort PR if count > 1.
+# pdm: parse pdm.lock (TOML, same shape as uv.lock)
+PDM_VER=$(python - <<EOF
+import tomllib
+d=tomllib.load(open('pdm.lock','rb'))
+def norm(n): return n.lower().replace('_','-').replace('.','-')
+print(next((p['version'] for p in d.get('package',[]) if norm(p['name'])=='$PKG_NORM'), ''))
+EOF
+)
+# Alternative: pdm list --json | jq
 
-     Special case for raw pip/pip-tools: a `requirements.txt` with `<pkg>>=X.Y.Z`
-     (not pinned exactly) is NOT a lockfile — re-resolves on every `pip install`.
-     Parity check needs version-pinning verification, not just file presence.
+# pipenv: parse Pipfile.lock (JSON, version pinned with leading "==")
+PIPENV_VER=$(jq -r --arg p '<pkg>' \
+  '(.default[$p].version // .develop[$p].version // "")' Pipfile.lock \
+  | sed -E 's/^==//')
 
-     Hash-pinned requirements (`--require-hashes`): after the bump, regenerate hashes
-     via `pip-compile --generate-hashes`. Forgetting breaks CI silently in dev,
-     loudly in prod. -->
+# pip (raw) / pip-tools: read requirements.txt — only meaningful if pinned exactly
+PIP_VER=$(grep -iE '^<pkg>==' requirements.txt 2>/dev/null \
+  | head -1 | sed -E 's/^[^=]+==//; s/[[:space:];].*$//')
+
+echo "poetry=$POETRY_VER uv=$UV_VER pdm=$PDM_VER pipenv=$PIPENV_VER pip=$PIP_VER"
+```
+
+Use only the variables for PMs actually in play; ignore the rest. All values must show the patched version (or higher).
+
+> **Note: a `requirements.txt` with `<pkg>>=X.Y.Z` (no exact `==`) is NOT a lockfile** — it re-resolves on every `pip install`. The parity check needs a pinned-exact value to be meaningful. If the project's `requirements.txt` uses `>=` ranges, treat that PM as having no committed lockfile and generate a temp resolution for the parity check (see next subsection).
+
+### Generating a temp lockfile (PMs without a committed lockfile)
+
+When CI uses a PM that has no committed lockfile (e.g. poetry-local + raw-pip-CI), generate a temp lockfile *just for the parity check*, then **delete it before commit**:
+
+| PM | Lockfile-only regen | Resulting file |
+|---|---|---|
+| poetry | `poetry lock --no-update` | `poetry.lock` |
+| uv | `uv lock` | `uv.lock` |
+| pdm | `pdm lock --no-sync` | `pdm.lock` |
+| pipenv | `pipenv lock` | `Pipfile.lock` |
+| pip-tools | `pip-compile requirements.in` (add `--generate-hashes` if hashed) | `requirements.txt` |
+| pip (raw) | `python -m pip install '<pkg>>=X.Y.Z' --dry-run --report /tmp/pip-resolve.json --quiet`, then `jq '.install[] | select(.metadata.name=="<pkg>") | .metadata.version' /tmp/pip-resolve.json` | (JSON report only, no file commit) |
+
+> ⚠ Do **NOT** commit a generated lockfile from a PM that doesn't already have one committed. Dual-lockfile drift is exactly the bug class this skill exists to prevent — a generated `requirements.txt` alongside an authoritative `poetry.lock` will silently diverge on the next regen and you've doubled the surface area, not halved it.
+
+When no lockfile is committed for a detected CI PM, also explicitly assert:
+
+- The override field for that PM is present in the manifest (see PM table in "Override pattern → Dual-write is MANDATORY").
+- The direct-dep range for the target package (if it's a direct dep) is consistent with the override.
+
+### 2. Lockfile parity (MANDATORY — abort PR on mismatch)
+
+```bash
+# Collect non-empty resolved versions across all detected PMs
+VERS=$(printf '%s\n' "$POETRY_VER" "$UV_VER" "$PDM_VER" "$PIPENV_VER" "$PIP_VER" \
+  | grep -v '^$' | sort -u)
+COUNT=$(echo "$VERS" | grep -c .)
+
+if [ "$COUNT" -eq 0 ]; then
+  echo "PARITY ABORT: could not resolve <pkg> in any lockfile"
+  exit 1
+fi
+if [ "$COUNT" -gt 1 ]; then
+  echo "PARITY ABORT: PMs disagree:"
+  echo "$VERS"
+  exit 1
+fi
+echo "PARITY OK: all PMs resolved <pkg>@$VERS"
+```
+
+If any pair of PMs resolves to different versions of the target package, **abort the PR**. Do NOT push, do NOT open the PR, do NOT commit a half-fixed state. Surface the mismatch to the user, with all versions and the likely cause:
+
+- Override missing from one of the PMs (most common — e.g. `[tool.uv] override-dependencies` written but `[tool.pdm.resolution] overrides` forgotten).
+- Poetry resolved the bump but the exported `requirements.txt` is stale — re-run `poetry export -o requirements.txt --without-hashes` (or with hashes if the project uses them).
+- `pip-tools` `requirements.txt` not regenerated after `requirements.in` edit — re-run `pip-compile`.
+- Hash-pinned `requirements.txt` left with stale hashes after a bump (will manifest as a `pip install --require-hashes` failure in CI, not as a version mismatch — regenerate hashes via `pip-compile --generate-hashes`).
+- `requires_python` skew — one PM's resolver picked an older version because the target's Python floor exceeds that PM's configured Python.
+
+Environment drift between dev and CI/CD (any PM pair: poetry-local + pip-CI, uv-local + pdm-CI, pipenv-local + raw-pip-CI, etc.) is the bug class this skill exists to prevent. The Parity Check is non-negotiable.
+
+### Don't trust install stdout
+
+`poetry lock --no-update` may print `No changes` even when the override forced a re-resolution and the lockfile actually changed. Same for `uv lock`, `pdm lock`, `pipenv lock` in some edge cases. ALWAYS run the verify commands above — they read the lockfile directly.
 
 {{include _shared/fragments/commit-pr-format.md}}
 
@@ -244,14 +405,8 @@ Installs into the right skills dir for your agent (Codex `~/.codex/skills`, Clau
 
 ## Platform notes
 
-<!-- TODO(py): Python-specific platform notes.
-     - **Native-wheel risk**: bumps of compiled packages (cryptography, lxml, numpy,
-       pandas, pillow, psycopg2, cffi, bcrypt, pyodbc, pyarrow) need platform-specific
-       wheel re-resolve. Check PyPI .releases[<ver>] filename list for manylinux /
-       musllinux / macosx / win_amd64 wheels matching every deploy target before
-       pinning. Patched version may drop a platform wheel → silent CI break.
-     - **Hash mismatches**: when dev and CI use different index URLs (private PyPI mirror,
-       devpi), hash-pinned requirements can fail with "hash mismatch" — same file,
-       different mirror's hash. Surface this if hash check fails.
-     - **requires_python skew**: bumping to a version with a higher Python floor than
-       the project supports breaks install on older Python deploys. -->
+- **Native-wheel risk**: bumps of compiled packages (`cryptography`, `lxml`, `numpy`, `pandas`, `pillow`, `psycopg2`, `cffi`, `bcrypt`, `pyodbc`, `pyarrow`, `grpcio`) can drop a platform wheel between versions. Verify wheels exist for every deploy-target platform tag (`manylinux2014_x86_64`, `manylinux2014_aarch64`, `musllinux_*`, `macosx_*`, `win_amd64`) AND every Python version (`cp310`, `cp311`, `cp312`) in the project's matrix before pinning. A missing wheel forces a source build on that target — silent CI break (slow build, may fail without compiler/headers).
+- **Hash mismatches**: when dev and CI use different index URLs (private PyPI mirror, devpi), hash-pinned requirements can fail with `hash mismatch` — same file, different mirror's hash. Surface this if a hash check fails on a bump that otherwise looks correct.
+- **`requires_python` skew**: bumping to a target whose `requires_python` floor exceeds the project's configured floor (`project.requires-python` / `tool.poetry.dependencies.python`) breaks install on older Python deploys. Check the target's `requires_python` via PyPI metadata before pinning.
+- **Distribution-name normalization**: PyPI normalizes `_` / `-` / `.` and case in distribution names. `pkg_a`, `pkg-a`, `Pkg.A` all refer to the same distribution at resolve time, but lockfile entries may use any of these spellings. When parsing lockfiles, normalize both sides (`.lower().replace('_','-').replace('.','-')`) before comparing names.
+- **Conda environments**: if the project also ships a `conda` env (`environment.yml` or `conda-lock.yml`), the conda channel may carry a different version of the package than PyPI. Out of scope for this skill — flag to user but don't try to fix.

--- a/skills/dependabot-triage/SKILL.md
+++ b/skills/dependabot-triage/SKILL.md
@@ -197,6 +197,8 @@ Three axes, in order:
 2. **Exposure** — see Exposure Mapping below. NOT a heuristic guess about whether the vuln is reachable. A categorization of where the package is imported, presented to the user as a surface-area summary.
 3. **CVSS** — tiebreaker only. Raw score without exposure context misleads (e.g. SSRF in axios shows 4.8 but matters more if axios is in Public/API).
 
+> **CVSS=0 fallback.** Dependabot returns `security_advisory.cvss.score: 0` (or `null`) when the advisory hasn't been scored yet — common for fresh GHSAs. Don't let an unscored alert sink to the bottom of a CVSS-sorted ranking; fall back to `security_advisory.severity` (always populated). Approximate score mapping: `critical` ≈ 9.5, `high` ≈ 7.5, `medium` ≈ 5.0, `low` ≈ 2.0. Surface the fallback explicitly in the ranked table — e.g. `cvss: — (high)` rather than `cvss: 0` — so the user understands why a high-severity alert sits above a low-CVSS one.
+
 ## Exposure Mapping
 
 Replaces the prior heuristic "reachability" model. Goal: stop trying to PROVE a vuln is unreachable — false negatives are dangerous. Instead, enumerate every import site of the target package and bucket each one. The user makes the final risk call from the surface area.


### PR DESCRIPTION
## Summary

Closes the scaffold-state gap in `dependabot-triage-py` left by PR #23. All 12 `TODO(py)` stubs in `SKILL.md.tmpl` replaced with concrete Python-ecosystem guidance; scaffold prefix dropped from the frontmatter `description:` and the scaffold blockquote removed from the H1 area so the agent router no longer flags the skill as incomplete.

## What changed

| Section | Now contains |
|---|---|
| **Detect PMs** (step 1) | Manifest/lockfile glob, `pyproject.toml [tool.*]` table grep, CI/Dockerfile install-command `rg`, hash-pinned-requirements flag, system-package false-positive guard |
| **Fetch alerts** (step 2) | `.ecosystem == "pip"` filter, mixed-ecosystem block-output, system-package false-positive guard |
| **Apply** (steps 10–11) | Env-marker / extras preservation; lockfile-only regen guidance |
| **Exposure: Categories** | 2-cat table (Client-Bundle dropped — Python rarely ships to browser); Streamlit/Gradio/Dash → Public/API; PyScript/Brython → JS skill |
| **Exposure: Enumeration** | dist→import name table (PyYAML/yaml, Pillow/PIL, opencv-python/cv2, scikit-learn/sklearn, etc.) + `importlib.metadata.packages_distributions()` resolver |
| **Exposure: Present** | Surface summary template adapted from JS (drops Client-Bundle row) |
| **Workflow per alert (1–8)** | Yanked-release check, `requires_python` compatibility check, wheel-availability check for compiled packages (`cryptography`, `lxml`, `numpy`, `pandas`, `pillow`, `psycopg2`, `cffi`, `bcrypt`, `pyodbc`, `pyarrow`, `grpcio`), PyPI changelog scrape via `info.project_urls` + sdist `CHANGELOG` fallback |
| **Override pattern** | 6-row PM table (pip / pip-tools / poetry / uv / pdm / pipenv). Explicit no-transitive-override carve-out for raw pip + pipenv → **Fast-Track hard-ineligible** in that case. Env-marker + extras preservation rule. |
| **Version range rules** | PEP 440 vs semver: `^` is poetry-only; `>=X.Y.Z,<(X+1).0.0` is universal; `~=X.Y.Z` is patch-only; pre-release exclusion in pip's default resolver |
| **Parity check** | Per-PM lockfile readers (TOML for poetry/uv/pdm, JSON for pipenv, grep for raw pip / pip-tools). Distribution-name normalization (`.lower().replace('_','-')`). Temp-lockfile-for-parity table. Hash-pinned regen guidance. |
| **Platform notes** | Native-wheel risk, hash mismatches across mirrors, `requires_python` skew, conda env out-of-scope |

## Mechanics / build

- `SKILL.md` rebuilt via `scripts/build-skill.sh dependabot-triage-py`. 16 shared-fragment includes resolved.
- `scripts/build-all-skills.sh` idempotent: rebuilding both leaves leaves no diff against committed `SKILL.md`s (modulo the file in this PR).
- `rg 'TODO\(py\)' skills/dependabot-triage-py/` → 0 matches.
- `rg 'scaffold' skills/dependabot-triage-py/` → 0 matches.
- Frontmatter parses with `yaml.safe_load` clean.
- Size delta: 30607 → 46832 bytes (620 lines). Slightly larger than JS sibling (580 / 41924) because the Python PM matrix is wider (5 vs 4) and two PMs need the dedicated no-override carve-out.

## What's NOT in this PR (deferred follow-ups from earlier review)

- JS package examples (`axios`, `dompurify`, Client-Bundle references) still appear in `_shared/fragments/*.md`. README banner explicitly flags this as illustrative-not-load-bearing. Repointing them at neutral examples is a separate fragment-edit PR.
- Defensive-minimum doc clarification (override lower-bound vs resolved version).
- Single-PM "parity vacuous" hint.

## Test plan

- [ ] CI build passes (if wired).
- [ ] Manual: `bash scripts/build-all-skills.sh && git diff --exit-code -- skills/*/SKILL.md` → clean.
- [ ] Manual: run the Python flow against a real pip / poetry / uv repo's Dependabot alerts end-to-end before publishing the `dependabot-triage-py` mirror tag.
- [ ] Skim `SKILL.md` section structure top-to-bottom (Override pattern, Version range rules, Verify Parity Check, Platform notes — all anchored as expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)