### PR TITLE
feat(skills): py — ghost-manifest detection + verify Dependabot PR target

### DIFF
--- a/skills/dependabot-triage-py/SKILL.md
+++ b/skills/dependabot-triage-py/SKILL.md
@@ -107,6 +107,13 @@ The early steps (1–4) are the same in both modes. The middle steps branch by m
      - **Zappa** (`zappa_settings.json`) — single-project pip deploy.
 
      These patterns hide the per-Lambda manifest split behind the framework. The recursive `find` above will surface every `requirements*.txt`; cross-reference each with the deploy manifest to figure out which Lambda owns it.
+   - **Ghost manifests (unused snapshots) — propose deletion, not a bump.** Not every committed `requirements*.txt` is wired into a deploy. A common Python-on-AWS pattern: someone committed a `pip freeze` snapshot from a dev machine alongside the lambda code "for reference"; the framework actually builds from a different file (e.g. a shared layer source at repo root). Dependabot will keep raising alerts on the snapshot anyway. Tells that a manifest is a ghost:
+     - Lines like `<pkg> @ file:///AppleInternal/...` (Mac system Python freeze leak), `file:///private/var/folders/...`, `file:///usr/local/...`, or any `file://` URL pointing at a path that only exists on one engineer's machine — these can't `pip install` outside that machine, so the file can't be the deploy source.
+     - No reference to this manifest in any deploy config (`serverless.yml` `pythonRequirements.fileName`, SAM `CodeUri`, CDK construct entry, Zappa `zappa_settings.json`, Dockerfile `COPY ... requirements.txt`, CI `pip install -r ...`).
+     - `package.individually: false` (Serverless Framework) rules out per-handler-dir bundling — so a `lambdas/<fn>/requirements.txt` *can't* be a deploy source.
+     - Git history shows only Dependabot bumps, never a human edit since initial commit.
+
+     When the cross-reference confirms a manifest is unused: surface to user as a deletion candidate, not a bump candidate. Bumping a ghost manifest closes alerts but leaves the dead file in place to generate the next round. Deletion is the structural fix. (Project-specific knowledge — e.g. "in repo X, `lambdas/<fn>/requirements.txt` files are ghosts" — should be recorded in repo CLAUDE.md or agent memory, not here.)
    - **Compare** committed manifests against CI install commands. If CI uses a different PM than the committed lockfile (e.g. `poetry.lock` committed but the Dockerfile runs `pip install -r requirements.txt`), expand the override + parity matrix accordingly (see "Override pattern" and "Verify (Parity Check)").
    - **Hash-pinned requirements flag** — if any `requirements*.txt` contains `--hash=sha256:` lines, this is a `pip-tools --generate-hashes` setup. Bumps require regenerating hashes; forgetting will break `pip install --require-hashes` in CI/prod.
    - **Don't ask the user up-front to classify the PM setup.** They often only know half the picture (their local context, not CI; or vice versa). Detect from manifest/lockfile + CI grep, show what was found, and ask only to confirm anomalies (e.g. *"I see `poetry.lock` committed but the Dockerfile runs `pip install -r requirements.txt` — confirm both are intentional?"*).
@@ -404,6 +411,7 @@ Assumes "Detect package managers in play" (workflow step 1) is already done — 
 4. **Exposure Mapping**: see "Exposure Mapping" section. Categorize every import site (Public/API · Internal/Dev) and produce a surface summary for the user.
 5. **Pick version (defensive minimal-patched, PEP 440)**:
    - Single alert: `>=X.Y.Z,<(X+1).0.0` of `first_patched_version`.
+   - **Do NOT trust an open Dependabot PR's target version.** Dependabot opens its PR against the alert that first triggered it; its target is `first_patched_version` of *that one alert*, not `max(first_patched_version)` across the full cluster of related alerts. In practice, a Dependabot PR can underpatch by several CVEs — leaving alerts open after merge. Always recompute the defensive minimum yourself across every alert in the cluster (see the cluster command below) and compare against the PR's target. If the PR underpatches, either re-target it or open a fresh PR at the correct version.
    - Cluster: same shape, `X.Y.Z = max(first_patched_version)` across every CVE in the cluster — i.e. the *minimal* version that supersets every patch. Compute via:
      ```bash
      for n in <alert-numbers>; do

--- a/skills/dependabot-triage-py/SKILL.md.tmpl
+++ b/skills/dependabot-triage-py/SKILL.md.tmpl
@@ -75,6 +75,13 @@ Installs into the right skills dir for your agent (Codex `~/.codex/skills`, Clau
      - **Zappa** (`zappa_settings.json`) — single-project pip deploy.
 
      These patterns hide the per-Lambda manifest split behind the framework. The recursive `find` above will surface every `requirements*.txt`; cross-reference each with the deploy manifest to figure out which Lambda owns it.
+   - **Ghost manifests (unused snapshots) — propose deletion, not a bump.** Not every committed `requirements*.txt` is wired into a deploy. A common Python-on-AWS pattern: someone committed a `pip freeze` snapshot from a dev machine alongside the lambda code "for reference"; the framework actually builds from a different file (e.g. a shared layer source at repo root). Dependabot will keep raising alerts on the snapshot anyway. Tells that a manifest is a ghost:
+     - Lines like `<pkg> @ file:///AppleInternal/...` (Mac system Python freeze leak), `file:///private/var/folders/...`, `file:///usr/local/...`, or any `file://` URL pointing at a path that only exists on one engineer's machine — these can't `pip install` outside that machine, so the file can't be the deploy source.
+     - No reference to this manifest in any deploy config (`serverless.yml` `pythonRequirements.fileName`, SAM `CodeUri`, CDK construct entry, Zappa `zappa_settings.json`, Dockerfile `COPY ... requirements.txt`, CI `pip install -r ...`).
+     - `package.individually: false` (Serverless Framework) rules out per-handler-dir bundling — so a `lambdas/<fn>/requirements.txt` *can't* be a deploy source.
+     - Git history shows only Dependabot bumps, never a human edit since initial commit.
+
+     When the cross-reference confirms a manifest is unused: surface to user as a deletion candidate, not a bump candidate. Bumping a ghost manifest closes alerts but leaves the dead file in place to generate the next round. Deletion is the structural fix. (Project-specific knowledge — e.g. "in repo X, `lambdas/<fn>/requirements.txt` files are ghosts" — should be recorded in repo CLAUDE.md or agent memory, not here.)
    - **Compare** committed manifests against CI install commands. If CI uses a different PM than the committed lockfile (e.g. `poetry.lock` committed but the Dockerfile runs `pip install -r requirements.txt`), expand the override + parity matrix accordingly (see "Override pattern" and "Verify (Parity Check)").
    - **Hash-pinned requirements flag** — if any `requirements*.txt` contains `--hash=sha256:` lines, this is a `pip-tools --generate-hashes` setup. Bumps require regenerating hashes; forgetting will break `pip install --require-hashes` in CI/prod.
    - **Don't ask the user up-front to classify the PM setup.** They often only know half the picture (their local context, not CI; or vice versa). Detect from manifest/lockfile + CI grep, show what was found, and ask only to confirm anomalies (e.g. *"I see `poetry.lock` committed but the Dockerfile runs `pip install -r requirements.txt` — confirm both are intentional?"*).
@@ -209,6 +216,7 @@ The user reads the surface and decides whether the bump is worth the risk — Cl
 4. **Exposure Mapping**: see "Exposure Mapping" section. Categorize every import site (Public/API · Internal/Dev) and produce a surface summary for the user.
 5. **Pick version (defensive minimal-patched, PEP 440)**:
    - Single alert: `>=X.Y.Z,<(X+1).0.0` of `first_patched_version`.
+   - **Do NOT trust an open Dependabot PR's target version.** Dependabot opens its PR against the alert that first triggered it; its target is `first_patched_version` of *that one alert*, not `max(first_patched_version)` across the full cluster of related alerts. In practice, a Dependabot PR can underpatch by several CVEs — leaving alerts open after merge. Always recompute the defensive minimum yourself across every alert in the cluster (see the cluster command below) and compare against the PR's target. If the PR underpatches, either re-target it or open a fresh PR at the correct version.
    - Cluster: same shape, `X.Y.Z = max(first_patched_version)` across every CVE in the cluster — i.e. the *minimal* version that supersets every patch. Compute via:
      ```bash
      for n in <alert-numbers>; do


### PR DESCRIPTION
## Summary

Two learnings from running `dependabot-triage-py` against `tern-of-mind` ([TernTechnologies/tern-of-mind#176](https://github.com/TernTechnologies/tern-of-mind/pull/176), [#177](https://github.com/TernTechnologies/tern-of-mind/pull/177)). Both generic enough to live in the skill, not in repo-specific memory.

### 1. Ghost-manifest detection (workflow step 1)

Not every committed `requirements*.txt` is consumed by a deploy. `pip freeze` snapshots committed "for reference" alongside lambda code generate Dependabot noise indefinitely. The skill already told the agent to *cross-reference each manifest with the deploy config* but didn't say what to do when cross-reference revealed the manifest is orphaned. Now it does: **propose deletion, not a bump**.

Tells encoded in the skill:
- `file:///AppleInternal/...` / `file:///private/var/folders/...` URLs — Mac-only paths that can't `pip install` in CI.
- No reference in any deploy config (`serverless.yml` `pythonRequirements.fileName`, SAM `CodeUri`, CDK construct, Dockerfile, CI install command).
- `package.individually: false` (Serverless Framework) → rules out per-handler-dir bundling.
- Git history shows only Dependabot bumps since init.

### 2. Verify Dependabot's own PR target (workflow step 5)

An open Dependabot PR targets `first_patched_version` of the **one** alert that triggered it, not `max(first_patched_version)` across the cluster. In practice it can underpatch by several CVEs — leaving alerts open after merge. Example: `tern-of-mind#143` proposed Pillow `12.1.1` while the 10-alert cluster needed `12.2.0`.

The defensive-minimum math was already correct; this adds an explicit instruction to compare against any existing Dependabot PR's target before accepting it.

## Test plan

- [ ] Confirm `build-skill.sh dependabot-triage-py` produces a clean rebuild (already verified locally — `16 includes resolved`, no template/output drift).
- [ ] Walk the next Python Dependabot triage on `tern-of-mind` (any non-ghost manifest) to confirm the new bullets don't disrupt the standard flow.
- [ ] Consider mirroring point 2 (verify Dependabot PR target) to the JS skill in a follow-up — same failure mode applies to npm groups, but kept out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)