### PR TITLE
feat(skills): session-loop — multi-day project pause/resume toolkit

### DIFF
--- a/scripts/publish-skill.sh
+++ b/scripts/publish-skill.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 declare -A MIRROR_REMOTES=(
   [dependabot-triage]="https://github.com/akshayrao14/dependabot-triage.git"
   [dependabot-triage-py]="https://github.com/akshayrao14/dependabot-triage-py.git"
+  [session-loop]="https://github.com/akshayrao14/session-loop.git"
 )
 
 SKILL="${1:-}"

--- a/skills/session-loop/LICENSE
+++ b/skills/session-loop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Akshay Rao
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/session-loop/README.md
+++ b/skills/session-loop/README.md
@@ -1,0 +1,153 @@
+# session-loop
+
+A pause/resume toolkit for multi-day agent-assisted projects (Claude Code, Codex, etc.). Provides a coherent set of slash commands that compose with append-only project ledgers — not a replacement for them.
+
+## Why this exists
+
+Multi-day projects fail at the seams. The work itself is fine. The handoffs between sessions are where context evaporates, decisions get re-litigated, and silent drift compounds.
+
+Existing agent primitives — context compaction, memory, in-session task lists — don't cover the pause/resume seam between sessions. `session-loop` is the missing scaffolding.
+
+## Commands
+
+| Slash form | Purpose |
+| --- | --- |
+| `/session-wrap` | End-of-session handoff. Safety gate (refuses dirty stops) + handoff write (UPDATES.md, ledger, NEXT_SESSION.md). May auto-commit its own artifacts only. |
+| `/session-catchup` | Start-of-session rehydration. Reads handoff, runs drift check, proposes next move. Replaces the built-in `/resume` (which loads chat transcripts, not project state). |
+| `/session-checkpoint` | Mid-session light save. For stepping away for an hour, not stopping for the day. |
+| `/session-drift` | Reality vs ledger reconcile. Read-only. Re-runs verification commands and probes resources from the last 3 ADs. |
+| `/session-decide` | Append an ADR-style decision to the project's ledger. Forces context/decision/alternatives/supersedes/blast-radius/reversibility fields. |
+| `/session-open-loops` | Scan unresolved threads across handoff, narrative log, ledger, in-repo TODOs, open PRs, pending tasks. Ranked. Read-only. |
+| `/session-compact-check` | Pre-compaction state persistence at a clean task boundary. Migrated from the standalone `/compact-check`. |
+
+All commands also auto-trigger from natural language phrases — `/session-wrap` from "let's stop here", `/session-catchup` from "pick up where we left off", etc.
+
+## Artifact contract
+
+`session-loop` writes to three files in the project root. The contract is convention — no command hard-fails if a file is missing, but the suite is most useful when all three exist.
+
+| File | Lifecycle | Owners |
+| --- | --- | --- |
+| `NEXT_SESSION.md` | Ephemeral. Overwritten by every `/session-wrap` and `/session-checkpoint`. | Write: wrap, checkpoint. Read: catchup, open-loops, compact-check (notes section only). |
+| `DECISIONS.md` (or `MIGRATION_LEDGER.md`, `PROJECT_LOG.md`, `docs/adr/`) | Append-only. Never retro-edit; supersede with new dated entries. | Write: decide. Read: catchup, drift, open-loops. |
+| `UPDATES.md` | Append-only narrative, newest-on-top, dated. | Write: wrap. Read: catchup, open-loops. |
+
+### Ledger auto-discovery
+
+Commands look for an existing append-only ledger in this order:
+
+1. `DECISIONS.md`
+2. `MIGRATION_LEDGER.md`
+3. `PROJECT_LOG.md`
+4. `ADR.md` or `docs/adr/` (directory)
+5. Any top-level `*.md` whose first 50 lines mention "append" and ("ledger" OR "ADR" OR "decision")
+
+First match wins. If none found, defaults to creating `DECISIONS.md` on first `/session-decide` invocation.
+
+This is how `session-loop` composes with projects that already have an external-brain ledger under a different name — no migration needed.
+
+## Install
+
+```bash
+npx skills add akshayrao14/session-loop
+```
+
+Installs the skill into your agent's skills dir (`~/.claude/skills/`, `~/.codex/skills/`, or `~/.agents/skills/`) and symlinks each slash command stub into the matching commands dir (e.g. `~/.claude/commands/`). Restart your agent session afterward.
+
+### Manual install (from a clone)
+
+```bash
+git clone https://github.com/akshayrao14/session-loop ~/session-loop
+bash ~/session-loop/install.sh
+```
+
+Set `SKILLS_HOME` to override auto-detection (e.g. `SKILLS_HOME=~/.claude/skills bash install.sh`). Set `FORCE=1` to replace stale symlinks (still refuses to overwrite real files).
+
+## Design principles
+
+- **Append-only**: Decisions and narrative are never retro-edited. Supersede with new entries — the historical record stays intact.
+- **Idempotent**: Every command is safe to rerun. `/session-wrap` twice in a row produces one handoff, not two duplicate entries.
+- **Verify, don't trust**: Handoffs include commands future-you re-runs to confirm world state. Prose claims are corroborated, not believed.
+- **Refuse dirty stops**: `/session-wrap` refuses to write a handoff if the working tree is dirty in dangerous ways. User cleans up or passes `--force <reason>`.
+- **Surface drift, don't paper over it**: `/session-catchup` and `/session-drift` re-run verification commands. Divergence is the first thing reported.
+- **Strict authority boundary**: Commands have full authority over their own artifacts (NEXT_SESSION.md, ledger entries they write, UPDATES.md) — they may write and commit those. They have **suggest-only** authority over user work (source code, infra files) — they never auto-fix, auto-stage, or auto-commit user-owned files.
+- **Compose with existing conventions**: If the project already has a `MIGRATION_LEDGER.md`, commands append to it rather than creating a parallel `DECISIONS.md`.
+
+## Typical usage
+
+### Day 1, end of session
+
+```
+> /session-wrap
+```
+
+Runs safety gate. If anything dangerous is uncommitted (secrets, conflict markers, half-applied IaC), refuses with a list. User cleans up. Re-run:
+
+```
+> /session-wrap
+```
+
+Writes `UPDATES.md` entry, appends any session decisions to the ledger, overwrites `NEXT_SESSION.md` with snapshot + verification commands + top 3 entry points. Prompts to commit handoff artifacts.
+
+### Day 2, fresh session
+
+```
+> /session-catchup
+```
+
+Reads `NEXT_SESSION.md`, runs the verification commands from day 1, diffs against current reality. If everything matches: prints summary + recommended next move. If drift: pauses, asks user to acknowledge before proceeding.
+
+### Mid-session, before risky operation
+
+```
+> Before I run helm upgrade, /session-drift
+```
+
+Probes ledger-claimed resources against actual cluster state. Surfaces concerning divergence.
+
+### Decision made in conversation
+
+```
+> We just decided to use Cognito Token Bridge for interim auth. /session-decide
+```
+
+Walks through ADR fields (context, decision, alternatives rejected, supersedes, blast radius, reversibility). Appends to ledger.
+
+### Stepping away for lunch
+
+```
+> /session-checkpoint
+```
+
+Light save. Overwrites `NEXT_SESSION.md` with minimal snapshot. No safety gate, no commit. Flags any irreversible boundary crossed since last save.
+
+### Periodic hygiene
+
+```
+> /session-open-loops
+```
+
+Ranked list of unresolved threads from every source. Useful before `/session-wrap` to make sure carry-forward is complete.
+
+## Examples that compose with existing ledgers
+
+If your project already has `MIGRATION_LEDGER.md` (append-only, AD-NNN format, supersede-don't-retro-edit), `session-loop` integrates seamlessly:
+
+- `/session-decide` discovers and appends to it.
+- `/session-catchup` reads the last 3 ADs.
+- `/session-drift` probes the resources named in those ADs' Blast radius fields.
+- `/session-wrap` appends new ADs for any in-session decisions and writes its `UPDATES.md` entry in a fresh `UPDATES.md` (separate from the ledger).
+
+No project structure changes required. The ledger's existing conventions stay in charge.
+
+## Not built-in to Claude Code
+
+For reference — these are not Claude Code primitives:
+
+- `/session-wrap` ≠ built-in `/compact` (which trims context, not session state).
+- `/session-catchup` ≠ built-in `/resume` (which loads chat transcripts, not project state).
+- The auto-memory system (`MEMORY.md`) explicitly excludes "in-progress work, temporary state" — it stores long-lived facts, not session handoff state. `session-loop` covers the gap.
+
+## License
+
+MIT — see [`LICENSE`](LICENSE).

--- a/skills/session-loop/README.md
+++ b/skills/session-loop/README.md
@@ -22,6 +22,8 @@ Existing agent primitives — context compaction, memory, in-session task lists 
 
 All commands also auto-trigger from natural language phrases — `/session-wrap` from "let's stop here", `/session-catchup` from "pick up where we left off", etc.
 
+**New to this? Read [`WALKTHROUGH.md`](WALKTHROUGH.md)** — a concrete day-1, day-2, day-3 walkthrough with sample outputs for every command. The rest of this README is reference; the walkthrough is the on-ramp.
+
 ## Artifact contract
 
 `session-loop` writes to three files in the project root. The contract is convention — no command hard-fails if a file is missing, but the suite is most useful when all three exist.
@@ -139,6 +141,30 @@ If your project already has `MIGRATION_LEDGER.md` (append-only, AD-NNN format, s
 - `/session-wrap` appends new ADs for any in-session decisions and writes its `UPDATES.md` entry in a fresh `UPDATES.md` (separate from the ledger).
 
 No project structure changes required. The ledger's existing conventions stay in charge.
+
+## Beyond engineering
+
+The core ideas — append-only ledger, handoff/rehydrate, drift check, ADR-style decisions, open-loops, idempotency — are domain-agnostic. The current *implementation surface* (probes, gates, examples) is engineering-flavored, but the loop applies to any multi-day work where session boundaries cost you context.
+
+Side-by-side mapping of how each concept translates per domain:
+
+| Concept | Engineering | Product management | Research | Long-form writing |
+|---|---|---|---|---|
+| **Wrap safety gate** | `git status` clean; no secrets uncommitted; no half-applied Helm/Terraform | Open Notion/Google docs saved; draft Slack/email reviewed; no unposted Loom uploads | Notes synced to repo; recent papers cited; experiment results captured | Draft saved; version tag applied; reviewer comments addressed |
+| **Verification command** | `git rev-parse HEAD`, `kubectl get pods`, `terraform plan -detailed-exitcode` | Linear issue state, Slack thread state, last-edit timestamp on key Notion page | Citation graph query, last-pulled-from-arxiv timestamp, dataset checksum | Word count delta, reviewer comment count, last published version diff |
+| **Irreversible boundary** | `helm install` succeeded, `terraform apply` succeeded, `gh pr merge`, image pushed | Message sent to exec channel, Linear issue marked Shipped, contract signed, vendor selected | Preprint posted to arXiv, dataset published, IRB filing submitted | Sent to editor, published, retracted/erratum filed |
+| **Ledger entry example** | "Use Cognito Token Bridge for interim auth (AD-007). Supersedes manual JWT minting." | "Defer Q3 launch to Q4 after stakeholder review. Supersedes earlier Q3 commit; cause: legal review timeline." | "Drop hypothesis H2 — invalidated by experiment 4 cohort B." | "Cut chapter 7 — pacing review by editor; consolidate into chapter 6 epilogue." |
+| **Open-loops source** | In-repo `TODO`/`FIXME`, open PRs, agent task list | Linear issues assigned + mentioned, Slack mentions unread, action items from last meeting notes | Reviewer comments on draft, undelivered experiment runs, papers queued for response | Beta-reader feedback, editor margin notes, unresearched citations |
+
+### How to use today vs how it will get better
+
+The narrative + ledger structure works for any domain right now. PMs, researchers, and writers can productively use `/session-wrap`, `/session-catchup`, `/session-decide`, and `/session-open-loops` — they capture intent, preserve decisions, and re-establish context the same way they do for engineers.
+
+What does **not** work yet for non-engineering domains: the auto-probes inside `/session-wrap`, `/session-drift`, and `/session-checkpoint` look for engineering signals (Helm, Terraform, kubectl, git internals). In a Notion-and-Linear workflow those gates no-op silently and drift checks have nothing to compare against. Outcome: the framework runs but the auto-checks feel empty.
+
+**Workaround today**: in `/session-wrap`, supply your own verification commands manually when prompted (Linear issue queries, Notion last-edit URLs, calendar queries). They land in `NEXT_SESSION.md` and `/session-catchup` will re-run them next session. Same mechanics, different probes.
+
+**Planned (not built)**: a lightweight profile system (`.session-loop-profile` in project root, plus `profiles/<name>.md` per domain) that swaps in domain-specific gate and probe sets at invocation time. Deferred until adoption proves the demand. If you'd use this, open an issue against the mirror repo — it's the signal the design needs.
 
 ## Not built-in to Claude Code
 

--- a/skills/session-loop/SKILL.md
+++ b/skills/session-loop/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: session-loop
+description: Multi-day project pause/resume toolkit for agent-assisted work. Provides a coherent set of sub-flows for ending a session safely (`/session-wrap`), rehydrating context at the start of the next session (`/session-catchup`), light mid-session saves (`/session-checkpoint`), reality-vs-ledger drift checks (`/session-drift`), append-only decision logging (`/session-decide`), unresolved-thread scans (`/session-open-loops`), and pre-compaction state persistence (`/session-compact-check`). Operates over a shared artifact contract — `NEXT_SESSION.md` for ephemeral handoff state, `DECISIONS.md` (or an existing ledger) for append-only ADRs, and `UPDATES.md` for dated narrative. Use when the user says "let's stop here", "wrap up", "pick up where we left off", "what was I doing", "before I touch X, check the world", "log this decision", "what's left open", or invokes any of the slash commands above. Designed for projects that span days or weeks where session boundaries are real and context is expensive to rebuild from scratch.
+---
+
+# Session Loop
+
+A pause/resume toolkit for multi-day projects worked on with agent assistants (Claude Code, Codex, etc.). Composes with append-only project ledgers — does **not** replace them.
+
+## Why this exists
+
+Multi-day projects fail at the seams. The work itself is fine. The handoffs between sessions are where context evaporates, decisions get re-litigated, and silent drift compounds. This skill is the missing scaffolding around `agent + project + ledger` that makes pause/resume robust.
+
+## Sub-flows
+
+| Slash form | When it fires | Sub-skill file |
+| --- | --- | --- |
+| `/session-wrap` | End of session. User says "stop for today", "let's wrap up", "I'm done". | [`sub/wrap.md`](sub/wrap.md) |
+| `/session-catchup` | Start of session. User says "pick up where we left off", "what was I doing", "resume the migration". | [`sub/catchup.md`](sub/catchup.md) |
+| `/session-checkpoint` | Mid-session light save. User says "stepping away for an hour", "save my place". | [`sub/checkpoint.md`](sub/checkpoint.md) |
+| `/session-drift` | Sanity check world vs ledger. User says "check the world before I run helm", "is the ledger still accurate". | [`sub/drift.md`](sub/drift.md) |
+| `/session-decide` | Log an ADR-style decision. User says "we just decided X, log it", "record this call". | [`sub/decide.md`](sub/decide.md) |
+| `/session-open-loops` | Scan unresolved threads. User says "what's still open", "what did we defer". | [`sub/open-loops.md`](sub/open-loops.md) |
+| `/session-compact-check` | Pre-compaction state persistence. User says "compact now", or context pressure is high at a task boundary. | [`sub/compact-check.md`](sub/compact-check.md) |
+
+## Shared artifact contract
+
+These files live in the project root. Each sub-flow reads and/or writes a defined subset. The contract is convention — no sub-flow hard-fails if a file is missing, but they are most useful when all three exist.
+
+| File | Lifecycle | Owner sub-flows |
+| --- | --- | --- |
+| `NEXT_SESSION.md` | Ephemeral. Overwritten on every `/session-wrap` and `/session-checkpoint`. Consumed by `/session-catchup`. | Write: `wrap`, `checkpoint`. Read: `catchup`, `open-loops`. |
+| `DECISIONS.md` (or project's existing ledger, e.g. `MIGRATION_LEDGER.md`) | Append-only. Never retro-edit; supersede with new dated entries. | Write: `decide`. Read: `catchup`, `drift`, `open-loops`. |
+| `UPDATES.md` | Append-only narrative, newest-on-top, dated. | Write: `wrap`. Read: `catchup`. |
+
+If the project already maintains an external-brain ledger under a different name (e.g. `MIGRATION_LEDGER.md`, `PROJECT_LOG.md`), each sub-flow auto-detects it — see "Ledger discovery" below.
+
+## Ledger discovery
+
+Sub-flows look for an existing append-only ledger in this order:
+
+1. `DECISIONS.md`
+2. `MIGRATION_LEDGER.md`
+3. `PROJECT_LOG.md`
+4. `ADR.md` or `docs/adr/`
+5. Any top-level `*.md` whose first 50 lines contain both "append" and ("ledger" OR "ADR" OR "decision")
+
+First match wins. If none found, sub-flows default to writing into `DECISIONS.md`. The chosen path is reported in output, so the user can correct it on the first run.
+
+## Design principles
+
+- **Append-only**: Decisions and narrative are never retro-edited. Supersede with new entries.
+- **Idempotent**: Every sub-flow is safe to rerun. `/session-wrap` twice in a row produces one handoff, not two duplicate entries.
+- **Verify, don't trust**: Handoffs include commands future-you re-runs to confirm world state. Prose claims are corroborated, not believed.
+- **Refuse dirty stops**: `/session-wrap` refuses to write a handoff if the working tree is dirty in dangerous ways (uncommitted secrets, half-applied IaC, orphaned cloud resources). User must clean up or pass `--force`.
+- **Surface drift, don't paper over it**: `/session-catchup` and `/session-drift` re-run verification commands. If reality has changed since handoff, the divergence is the first thing reported.
+- **Compose with existing conventions**: If the project already has a `MIGRATION_LEDGER.md`, sub-flows append to it rather than creating a parallel `DECISIONS.md`.
+
+## Installation
+
+```bash
+npx skills add akshayrao14/session-loop
+```
+
+Installs into the right skills dir for your agent (Codex `~/.codex/skills`, Claude Code `~/.claude/skills`, or open-standard `~/.agents/skills`). Restart your agent session afterward.
+
+## Trigger phrases (umbrella)
+
+Any of these route the agent to this skill, which then dispatches to the right sub-flow:
+
+- "Let's wrap up" / "Stop for today" / "End of session" → `/session-wrap`
+- "Pick up where we left off" / "What was I doing" / "Resume" → `/session-catchup`
+- "Save my place" / "Stepping away" → `/session-checkpoint`
+- "Check the world" / "Drift check" / "Is the ledger still accurate" → `/session-drift`
+- "Log this decision" / "Record this call" / "Add an ADR" → `/session-decide`
+- "What's still open" / "What did we defer" → `/session-open-loops`
+- "Compact now" / context pressure at task boundary → `/session-compact-check`
+
+## Dispatch
+
+When this skill activates without a clear slash form, dispatch by intent:
+
+1. If the user is asking to **end** work → load `sub/wrap.md`.
+2. If the user is asking to **start** or **resume** work → load `sub/catchup.md`.
+3. If the user is asking to **verify** project state → load `sub/drift.md`.
+4. If the user is asking to **record** a decision → load `sub/decide.md`.
+5. If the user is asking what is **unresolved** → load `sub/open-loops.md`.
+6. If the user wants a **light save** (not full wrap) → load `sub/checkpoint.md`.
+7. Pre-compaction at a task boundary → load `sub/compact-check.md`.
+
+Each sub-file is self-contained: load only the one that matches.
+
+## Versioning
+
+This skill is published as an umbrella. All sub-flows version together to keep the artifact contract coherent. See [`README.md`](README.md) for the changelog.

--- a/skills/session-loop/WALKTHROUGH.md
+++ b/skills/session-loop/WALKTHROUGH.md
@@ -1,0 +1,332 @@
+# Walkthrough — first three sessions
+
+Concrete day-by-day example of how `session-loop` actually feels in practice. Sample outputs are illustrative — your project's outputs will differ in detail but the shape stays the same.
+
+## Prerequisites
+
+- `session-loop` installed (`npx skills add akshayrao14/session-loop` or run `install.sh` from a local clone).
+- Agent session restarted after install — confirm with `/help` or by typing `/session-` and seeing the seven commands in autocomplete.
+- A real multi-day project. Solo tasks under a day get no value from this; the cost of the wrap/catchup ritual exceeds the benefit until cold-start cost actually hurts.
+
+The walkthrough uses an engineering example (a service migration). The same shape works for non-engineering multi-day work — see the **Beyond engineering** section in [`README.md`](README.md) for the mapping.
+
+## Session 1 — bootstrap
+
+Scenario: spent four hours on day one of an AWS-to-Azure migration. Got the Helm chart rendering cleanly, applied to dev cluster, pods are running but the readiness probe is flapping. Time to stop.
+
+### You type
+
+```
+let's wrap up for today
+```
+
+### What the agent does
+
+Recognizes the intent, loads `sub/wrap.md`, runs Phase 1 (safety gate) first.
+
+```
+═══ /session-wrap — Phase 1 (stop-safety gate) ═══
+
+| Gate                          | Status | Detail                                  |
+|-------------------------------|--------|-----------------------------------------|
+| Git working tree              | WARN   | 3 files modified, 1 untracked           |
+| Sensitive uncommitted files   | PASS   |                                         |
+| Branch ahead of origin        | WARN   | 2 commits ahead — consider pushing      |
+| IaC drift (terraform/helm)    | PASS   |                                         |
+| Cloud resources this session  | INFO   | 2 created (aks-uaen-dev, helm release)  |
+| Open agent tasks              | PASS   |                                         |
+| Conflict markers              | PASS   |                                         |
+
+Result: WARN only. No hard fails. Proceed to Phase 2?
+```
+
+You confirm. If a FAIL had appeared (e.g. `.env.local` was unstaged), the agent would stop and list the fix — never auto-`git add` for you.
+
+### Phase 2 — handoff write
+
+```
+═══ /session-wrap — Phase 2 (handoff write) ═══
+
+1. Ledger discovery: found MIGRATION_LEDGER.md in project root.
+2. Captured verification commands:
+     - git rev-parse HEAD → 7a3c9f2
+     - git status --porcelain → 3 modified, 1 untracked
+     - kubectl -n auth-dev get pods → 1 Running (readiness flapping)
+     - helm list -n auth-dev → auth-ternity-0.1.0 deployed
+3. Wrote new entry to UPDATES.md (top).
+4. Logged 1 decision to MIGRATION_LEDGER.md as AD-008
+   (chose probe-period 30s after initial 10s caused thrash).
+5. Wrote NEXT_SESSION.md (overwrote prior).
+
+Handoff written:
+  - UPDATES.md          (+1 entry)
+  - MIGRATION_LEDGER.md (+1 AD entry: AD-008)
+  - NEXT_SESSION.md     (overwritten)
+
+Commit handoff artifacts? [y/N]
+```
+
+You answer `y`. Agent runs:
+
+```bash
+git add UPDATES.md MIGRATION_LEDGER.md NEXT_SESSION.md
+git commit -m "chore(session): wrap 2026-05-25"
+```
+
+Final output:
+
+```
+Commit:
+  abc123e chore(session): wrap 2026-05-25
+
+Resume command:
+  /session-catchup
+```
+
+### What `NEXT_SESSION.md` looks like now
+
+(Abridged — see `templates/NEXT_SESSION.md` for full structure.)
+
+```markdown
+# Handoff — 2026-05-25 17:42 UTC
+
+## Snapshot
+
+| Field          | Value                                       |
+| -------------- | ------------------------------------------- |
+| Wrap kind      | wrap                                        |
+| Branch         | feat/auth-ternity-aks                       |
+| Git HEAD       | 7a3c9f2                                     |
+| Ahead of origin| 2 commits                                   |
+| Working tree   | dirty (3 modified, 1 untracked)             |
+
+## What I was doing
+
+Migrating auth-ternity from AWS Lambda (me-central-1) to AKS UAE North.
+Got the Helm chart rendering cleanly, applied to dev cluster, pods are
+Running but the readiness probe is flapping. Suspect the JWKS cache
+initialization is racing with the first request.
+
+## Where I stopped
+
+After bumping initialDelaySeconds from 10 to 30. Pod stabilized but
+the third pod hasn't passed readiness in 4 minutes — likely a different
+root cause than the cache race.
+
+## Top 3 candidate entry points
+
+1. **Diagnose pod-3 readiness** — `kubectl describe pod auth-ternity-xxx -n auth-dev`, look at probe events for the specific failure mode
+2. **JWKS cache instrumentation** — add a log line at cache init to confirm/deny the race hypothesis
+3. **Cloudflare → Azure DNS delegation for dev.uae.tern-group.com** — separate AD-007 thread, also waiting
+
+## Recommended start
+
+#1 because pod-3 is the only blocker for the dev deploy completing.
+
+## Verification commands
+
+$ git rev-parse HEAD
+7a3c9f2
+
+$ kubectl -n auth-dev get pods
+NAME                            READY   STATUS    RESTARTS
+auth-ternity-7f8b9c-x2k4l       1/1     Running   0
+auth-ternity-7f8b9c-q3n5p       1/1     Running   0
+auth-ternity-7f8b9c-r8m1z       0/1     Running   0
+
+$ helm list -n auth-dev
+NAME             STATUS     CHART
+auth-ternity     deployed   auth-ternity-0.1.0
+```
+
+You log off.
+
+## Session 2 — catchup next morning
+
+You come back. Fresh shell. Agent session restarted (or new conversation).
+
+### You type
+
+```
+pick up where we left off
+```
+
+### What the agent does
+
+Loads `sub/catchup.md`. Reads `NEXT_SESSION.md`, last `UPDATES.md` entry, last three ADs from `MIGRATION_LEDGER.md`. Re-runs the verification commands.
+
+```
+═══ /session-catchup — drift check ═══
+
+Re-running verification commands from 2026-05-25 17:42 UTC (15h ago):
+
+| Command                              | Wrap output           | Now                    | Match? |
+|--------------------------------------|-----------------------|------------------------|--------|
+| git rev-parse HEAD                   | 7a3c9f2               | 7a3c9f2                | ✓      |
+| git status --porcelain               | 3 modified, 1 untrack | 3 modified, 1 untrack  | ✓      |
+| kubectl -n auth-dev get pods         | 1 Running, 1 flapping | 2 Running, 1 Pending   | DIFFER |
+| helm list -n auth-dev                | auth-ternity 0.1.0    | auth-ternity 0.1.0     | ✓      |
+
+⚠ Drift detected:
+
+  Kubernetes pods changed:
+    wrap:    auth-ternity-7f8b9c-r8m1z Running (readiness flapping)
+    now:     auth-ternity-7f8b9c-r8m1z Pending — ImagePullBackOff (15h)
+    likely:  registry credential rotated overnight, or image was retagged
+
+What's the right read here? Was this expected?
+```
+
+You investigate the pod, find the ACR pull secret expired, refresh it. Re-run `/session-catchup` (idempotent).
+
+```
+═══ Catchup summary ═══
+
+Project:       tern-infra (auth-ternity migration)
+Last session:  2026-05-25 (16h ago)
+Wrap status:   clean
+
+What happened last time:
+  Helm chart applied to dev cluster. 2 of 3 pods Running. Bumped
+  readiness initialDelaySeconds from 10 to 30. Pod-3 still failing
+  readiness for a different reason than the cache race.
+
+Recent decisions (last 3 ADs):
+  AD-006: Use Azure Service Bus for queues + Event Grid for events
+  AD-007: Cloudflare → Azure DNS via NS delegation (no Front Door in dev)
+  AD-008: readiness initialDelaySeconds 30s (was 10s — caused thrash)
+
+Open threads from handoff:
+  - Diagnose pod-3 readiness failure (top priority)
+  - JWKS cache instrumentation (hypothesis test)
+  - DNS delegation for dev.uae.tern-group.com (waiting)
+
+World state:
+  ✓ All verification commands match handoff
+  (post ACR creds refresh)
+
+Candidate entry points:
+  1. Diagnose pod-3 readiness — `kubectl describe pod ...`
+  2. JWKS cache instrumentation
+  3. DNS delegation
+
+Recommend starting with #1 because pod-3 is the only blocker for dev deploy.
+
+What would you like to tackle first?
+```
+
+You start with #1.
+
+## Session 3 — mid-session patterns
+
+Throughout session 3 you use the supporting commands as needed.
+
+### Drift check before a risky operation
+
+You're about to run `helm upgrade`. Before doing so:
+
+```
+before I run helm upgrade, drift check
+```
+
+`/session-drift` re-runs the verification commands and probes resources named in recent ADs (`Blast radius` fields). Read-only. If anything changed since `/session-catchup` ran, it surfaces here. Crucial because changes between catchup and now might invalidate your assumptions.
+
+### Logging a decision in conversation
+
+Mid-session you decide:
+
+> Actually, let's use the static JWKS file we already have rather than fetching at boot. Network call at init was probably the race cause.
+
+You realize this is an AD-worthy decision and say:
+
+```
+log that as a decision
+```
+
+`/session-decide` walks you through the required fields (context, decision, alternatives rejected, supersedes, blast radius, reversibility). The context section explicitly mentions superseding AD-008 (the initialDelaySeconds tweak — turns out the root cause was different). Appends `AD-009` to `MIGRATION_LEDGER.md`. Does **not** retro-edit AD-008 — AD-008 stays verbatim, AD-009 supersedes it.
+
+### Stepping away for an hour
+
+You have a meeting. Not stopping for the day, just pausing.
+
+```
+/session-checkpoint
+```
+
+Lighter than wrap. No safety gate. Overwrites `NEXT_SESSION.md` with a minimal snapshot:
+- One sentence about what you were doing.
+- One next step.
+- Two verification commands.
+
+Also flags: "since last save, you committed AD-009 (irreversible: ledger appended). Acknowledge?" You confirm.
+
+### Periodic hygiene
+
+Late in the day, before your next wrap:
+
+```
+what's still open
+```
+
+`/session-open-loops` aggregates from `NEXT_SESSION.md`, `UPDATES.md`, ledger ADs without follow-up, in-repo TODOs, open PRs, and pending agent tasks. Ranks them:
+
+```
+═══ Open loops ═══
+
+Top priority:
+  1. [BLOCKER] DNS delegation for dev.uae.tern-group.com (carry-forward, AD-007)
+  2. [PR REVIEW] auth-ternity #142 (assigned to you, CI passing)
+  3. [AD FOLLOW-UP] AD-009 supersedes AD-008 — pod-3 should be retested
+
+Medium:
+  4. JWKS cache instrumentation — completed by AD-009? Verify or close.
+  5. TODO in helm/templates/deployment.yaml line 47: "revisit resource requests"
+
+Low:
+  6-12. ...
+```
+
+Item #4 prompts you to check whether the instrumentation thread is now moot (AD-009 made it irrelevant). It is — you close that thread in your head before wrap.
+
+### End of session 3
+
+You wrap again. AD-009 is already in the ledger from earlier. The wrap notes that item #4 was resolved, item #3 (pod-3 retest) is the new top entry point for session 4.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Agent didn't auto-trigger `/session-wrap` on "let's stop" | Phrase didn't match SKILL.md description | Type `/session-wrap` explicitly. Optionally edit SKILL.md to add your phrasing. |
+| Ledger discovery picked the wrong file | Multiple candidates in project root | First-run output names the chosen ledger. Rename or move the wrong candidate, re-invoke. |
+| `NEXT_SESSION.md` is in `.gitignore` | Some teams prefer the handoff untracked | Wrap detects this and prints `NEXT_SESSION.md is gitignored — leaving uncommitted`. UPDATES + ledger still committed. |
+| Drift check says "auth expired" | `az`/`gh`/`kubectl` token timed out | Refresh per the printed command (`az login`, `gh auth refresh`, etc.). Re-run `/session-drift`. |
+| Catchup says "handoff is N days old, run /session-drift" | Long gap since last wrap | Run the suggested `/session-drift` first. Expect more drift; focus on the Concerning section. |
+| `/session-wrap` refuses, FAIL on sensitive files | `.env*`, `*.key`, `*.pem` are uncommitted | Commit them deliberately (if they belong in git) or `.gitignore` them. Don't `--force` past this — it's the highest-value gate. |
+| Wrap appended AD-NNN but you change your mind | Append-only ledger; no delete | Write a new AD that supersedes. Prior AD stays verbatim. The history matters more than the apparent contradiction. |
+
+## When NOT to use
+
+`session-loop` overhead pays off only when the cost of cold-starting a session is real. Skip it for:
+
+- **Solo tasks under a day.** No handoff needed.
+- **Throwaway exploration.** State that won't matter tomorrow.
+- **Pair-programming sessions** where another human is the carry-forward.
+- **Bug-fix sprints** where nothing accumulates between sessions — each bug is independent.
+- **Tasks where you only run agents for short bursts** and never close the chat.
+
+A reasonable threshold: invoke session-loop when at least *two* of these are true: project will span >3 days, multiple decisions accumulate, infrastructure or external state is mutated, sessions cross calendar days, multiple agents/humans collaborate asynchronously.
+
+## What success looks like after a week
+
+- `MIGRATION_LEDGER.md` (or your project's ledger) has 5–10 new AD entries with `Supersedes` chains where decisions evolved.
+- `UPDATES.md` has 4–7 dated entries with clear narrative.
+- `NEXT_SESSION.md` is overwritten cleanly between sessions — never stale.
+- `/session-catchup` consistently re-establishes context in under 30 seconds of agent output.
+- `/session-drift` catches at least one out-of-band change you would otherwise have missed (someone pulled, infra rolled back, secret rotated).
+- You never feel the "wait what was I doing" tax at the start of a session.
+
+If you're not seeing those after a week, something is off — usually:
+
+- `/session-wrap` is being skipped on rushed end-of-day stops.
+- Decisions are happening in conversation but `/session-decide` isn't being invoked.
+- The ledger auto-discovered the wrong file (check the wrap output's first lines).

--- a/skills/session-loop/commands/session-catchup.md
+++ b/skills/session-loop/commands/session-catchup.md
@@ -1,0 +1,11 @@
+---
+description: Start-of-session rehydration. Reads NEXT_SESSION.md + UPDATES.md tail + last 3 ADs, runs drift check on prior verification commands, proposes next move. See session-loop skill.
+---
+
+Invoke the **session-loop** skill with focus=catchup. Load `sub/catchup.md` from the skill directory and follow it exactly.
+
+Args (optional):
+
+- `--focus <thread>` — bias the recommendation toward a specific open thread from the handoff.
+
+Replaces the built-in `/resume` (which loads a chat transcript, not project state). Acts on the current working directory's project.

--- a/skills/session-loop/commands/session-checkpoint.md
+++ b/skills/session-loop/commands/session-checkpoint.md
@@ -1,0 +1,7 @@
+---
+description: Mid-session light save. Overwrites NEXT_SESSION.md with a minimal snapshot. Flags newly-crossed irreversible boundaries since last save. See session-loop skill.
+---
+
+Invoke the **session-loop** skill with focus=checkpoint. Load `sub/checkpoint.md` from the skill directory and follow it exactly.
+
+Lighter than `/session-wrap`. Use when stepping away for an hour or two, not stopping for the day. Does not append to UPDATES.md, does not append to ledger, does not commit.

--- a/skills/session-loop/commands/session-compact-check.md
+++ b/skills/session-loop/commands/session-compact-check.md
@@ -1,0 +1,7 @@
+---
+description: Self-assess whether to compact context window at a task boundary, persisting carry-forward state to NEXT_SESSION.md (or task metadata) before any compaction. See session-loop skill.
+---
+
+Invoke the **session-loop** skill with focus=compact-check. Load `sub/compact-check.md` from the skill directory and follow it exactly.
+
+Migrated from the standalone `/compact-check` command. If you have `~/.claude/commands/compact-check.md` from before installing session-loop, both will coexist — remove the standalone one when you've confirmed `/session-compact-check` works.

--- a/skills/session-loop/commands/session-decide.md
+++ b/skills/session-loop/commands/session-decide.md
@@ -1,0 +1,11 @@
+---
+description: Append ADR-style decision to the project's ledger. Forces context/decision/alternatives/supersedes/blast-radius/reversibility fields. Append-only — never retro-edits. See session-loop skill.
+---
+
+Invoke the **session-loop** skill with focus=decide. Load `sub/decide.md` from the skill directory and follow it exactly.
+
+Args (optional):
+
+- `--commit` — auto-commit the ledger after appending (otherwise suggests the commit command only).
+
+Uses the template at `templates/DECISION.md`. Discovered ledger order: `DECISIONS.md` → `MIGRATION_LEDGER.md` → `PROJECT_LOG.md` → `docs/adr/`.

--- a/skills/session-loop/commands/session-drift.md
+++ b/skills/session-loop/commands/session-drift.md
@@ -1,0 +1,11 @@
+---
+description: Reality vs ledger reconcile. Re-runs verification commands and probes resources from the last 3 ADs. Surfaces concerning divergence. Read-only. See session-loop skill.
+---
+
+Invoke the **session-loop** skill with focus=drift. Load `sub/drift.md` from the skill directory and follow it exactly.
+
+Args (optional):
+
+- `--snapshot` — also write raw probe output to `.session-drift/<timestamp>.txt` for later inspection.
+
+Read-only — never writes to NEXT_SESSION.md, the ledger, or any other artifact. Use before risky operations or when confidence in the ledger is low.

--- a/skills/session-loop/commands/session-open-loops.md
+++ b/skills/session-loop/commands/session-open-loops.md
@@ -1,0 +1,7 @@
+---
+description: Scan unresolved threads across NEXT_SESSION.md, UPDATES.md, ledger ADs without follow-up, in-repo TODOs, open PRs, and pending agent tasks. Ranks by urgency. Read-only. See session-loop skill.
+---
+
+Invoke the **session-loop** skill with focus=open-loops. Load `sub/open-loops.md` from the skill directory and follow it exactly.
+
+Useful before `/session-wrap` to make sure carry-forward is complete, or anytime as project hygiene. Read-only — never auto-closes or modifies anything.

--- a/skills/session-loop/commands/session-wrap.md
+++ b/skills/session-loop/commands/session-wrap.md
@@ -1,0 +1,13 @@
+---
+description: End-of-session safety gate + handoff write. Refuses dirty stops; writes UPDATES.md, ledger entries, and NEXT_SESSION.md. See session-loop skill.
+---
+
+Invoke the **session-loop** skill with focus=wrap. Load `sub/wrap.md` from the skill directory and follow it exactly.
+
+Args (optional):
+
+- `--force <reason>` — override the stop-safety gate. Reason is logged into the handoff.
+- `--auto-commit` — skip the commit prompt and commit handoff artifacts immediately.
+- `--no-commit` — skip the commit prompt and do not commit (for non-interactive runs).
+
+Acts on the current working directory's project. Reads/writes `NEXT_SESSION.md`, `UPDATES.md`, and the discovered ledger.

--- a/skills/session-loop/install.sh
+++ b/skills/session-loop/install.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Install session-loop:
+#   1) symlink the umbrella skill into the agent's skills dir
+#   2) symlink each command stub under commands/*.md into the agent's commands dir
+#
+# Refuses to overwrite existing files. Set FORCE=1 to allow replacement of
+# stale symlinks pointing elsewhere (still won't overwrite real files).
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_NAME="$(basename "$SKILL_DIR")"
+COMMANDS_SRC="$SKILL_DIR/commands"
+
+# Auto-detect target via SKILLS_HOME (generic) or legacy CLAUDE_SKILLS_HOME.
+# Falls back to first existing agent dir, else ~/.agents/skills (open standard).
+SKILLS_HOME="${SKILLS_HOME:-${CLAUDE_SKILLS_HOME:-}}"
+if [[ -z "$SKILLS_HOME" ]]; then
+  if [[ -d "$HOME/.codex" ]]; then
+    SKILLS_HOME="$HOME/.codex/skills"
+  elif [[ -d "$HOME/.claude" ]]; then
+    SKILLS_HOME="$HOME/.claude/skills"
+  else
+    SKILLS_HOME="$HOME/.agents/skills"
+  fi
+fi
+
+# The commands dir is the sibling of the skills dir for Claude Code:
+#   ~/.claude/skills/   <-- SKILLS_HOME
+#   ~/.claude/commands/ <-- COMMANDS_HOME
+# Same parent layout for Codex (~/.codex/) and the open agent dir (~/.agents/).
+COMMANDS_HOME="${COMMANDS_HOME:-$(dirname "$SKILLS_HOME")/commands}"
+
+mkdir -p "$SKILLS_HOME"
+mkdir -p "$COMMANDS_HOME"
+
+link_one() {
+  local src="$1"
+  local target="$2"
+  local label="$3"
+
+  if [[ -L "$target" ]]; then
+    local existing
+    existing="$(readlink "$target")"
+    if [[ "$existing" == "$src" ]]; then
+      echo "  = $label already linked: $target"
+      return 0
+    fi
+    if [[ "${FORCE:-0}" == "1" ]]; then
+      echo "  ~ $label replacing stale symlink: $target"
+      rm "$target"
+    else
+      echo "  ! $label refuses to overwrite existing symlink: $target -> $existing"
+      echo "    Set FORCE=1 to replace, or remove it manually."
+      return 1
+    fi
+  elif [[ -e "$target" ]]; then
+    echo "  ! $label refuses to overwrite existing file (not a symlink): $target"
+    echo "    Move it aside manually if you want to install session-loop here."
+    return 1
+  fi
+
+  ln -s "$src" "$target"
+  echo "  + $label installed: $target -> $src"
+}
+
+echo "Installing session-loop skill"
+echo "  skills home:   $SKILLS_HOME"
+echo "  commands home: $COMMANDS_HOME"
+echo
+
+skill_target="$SKILLS_HOME/$SKILL_NAME"
+link_one "$SKILL_DIR" "$skill_target" "skill"
+
+echo
+echo "Installing slash command stubs"
+
+shopt -s nullglob
+fail=0
+for cmd_file in "$COMMANDS_SRC"/*.md; do
+  cmd_name="$(basename "$cmd_file")"
+  cmd_target="$COMMANDS_HOME/$cmd_name"
+  if ! link_one "$cmd_file" "$cmd_target" "  $cmd_name"; then
+    fail=1
+  fi
+done
+
+echo
+if [[ $fail -eq 1 ]]; then
+  echo "One or more command stubs were not installed. See messages above."
+  exit 1
+fi
+
+echo "Done."
+echo
+echo "Restart your agent session to pick up the new skill and commands."
+echo
+echo "Try:"
+echo "  /session-wrap       - end-of-session handoff"
+echo "  /session-catchup    - start-of-session rehydrate"
+echo "  /session-checkpoint - mid-session light save"
+echo "  /session-drift      - reality vs ledger reconcile"
+echo "  /session-decide     - log a decision"
+echo "  /session-open-loops - scan unresolved threads"
+echo "  /session-compact-check - pre-compaction state persistence"

--- a/skills/session-loop/sub/catchup.md
+++ b/skills/session-loop/sub/catchup.md
@@ -1,0 +1,128 @@
+# `/session-catchup` — start-of-session rehydration
+
+Read the prior session's handoff, verify the world still matches, then propose the next move. Replaces the built-in `/resume` (which loads a chat transcript, not project state).
+
+## When to invoke
+
+- Start of a new session on a multi-day project.
+- User says "pick up where we left off", "what was I doing", "resume the migration".
+- Fresh shell, fresh worktree, fresh agent — no memory of prior session.
+
+## Procedure
+
+### Step 1: locate handoff
+
+Look for `NEXT_SESSION.md` in the project root. If missing:
+
+- Check git log for a recent commit message mentioning "wrap" or "handoff" — surface it.
+- Read the top entry of `UPDATES.md` if present — surface its `Open threads` section.
+- Print: `No NEXT_SESSION.md found. Falling back to UPDATES.md tail. Run /session-wrap at the end of next session to enable full rehydrate.`
+
+### Step 2: read and parse
+
+Parse `NEXT_SESSION.md`. Extract:
+
+- Handoff timestamp.
+- Git HEAD at wrap.
+- Branch name.
+- Verification commands.
+- Top 3 candidate entry points.
+- Blockers / unanswered questions.
+- Resume command (if specified beyond `/session-catchup`).
+
+Read the **top entry** of `UPDATES.md` (newest narrative). Read the **last 3 AD entries** from the ledger (`DECISIONS.md` or discovered).
+
+### Step 3: drift check
+
+This is the critical step. Do **not** skip it, even if the user is impatient.
+
+Re-run every verification command from the handoff. For each:
+
+| Command | Wrap output | Now | Match? |
+| --- | --- | --- | --- |
+
+If **all match**: print `World matches handoff. Safe to resume.`
+
+If **any differ**: build a divergence table. For each divergence, classify:
+
+- **Expected** — natural drift since handoff (timestamps, log lines, pod restart counts within tolerance).
+- **Concerning** — material change (different git HEAD, new resources, branch diverged from origin, pod count changed, deployment status flipped).
+
+For concerning items: list them prominently and **pause**. Do not propose next steps until the user acknowledges or explains the divergence. Examples of how to surface:
+
+```
+⚠ Drift detected since wrap (2026-05-25 19:30):
+
+  Git HEAD changed:
+    wrap:    abc1234
+    now:     def5678
+    diff:    `git log abc1234..def5678 --oneline`
+
+  Kubernetes pods changed:
+    wrap:    auth-ternity-7f8b9c-x2k4l Running
+    now:     auth-ternity-9d2a1b-q7n3m Running
+    likely:  pod was restarted or redeployed since wrap
+
+What's the right read here? Was this expected, or did something happen out-of-band?
+```
+
+### Step 4: detect worktree identity
+
+Compare current `git rev-parse --show-toplevel` against the handoff's recorded path (if recorded). Detect:
+
+- **Same worktree, same machine**: full continuity. Use the handoff verbatim.
+- **Same worktree, different commit**: someone (or you) committed/pulled since wrap. Drift check covers this.
+- **Different worktree** (e.g. user re-cloned): warn. Untracked artifacts (`NEXT_SESSION.md`) won't be present in a fresh clone — confirm they were committed or are available some other way.
+
+### Step 5: propose next move
+
+Only after drift is acknowledged. Output format:
+
+```
+═══ Catchup summary ═══
+
+Project:       <directory or project name>
+Last session:  YYYY-MM-DD (N days ago)
+Wrap status:   clean | forced (reason: ...) | no NEXT_SESSION.md
+
+What happened last time:
+  <1–3 sentences from UPDATES.md top entry>
+
+Recent decisions (last 3 ADs):
+  AD-NNN: <title>
+  AD-NNN: <title>
+  AD-NNN: <title>
+
+Open threads from handoff:
+  - <thread 1>
+  - <thread 2>
+
+World state:
+  ✓ All verification commands match handoff
+  (or: drift table from step 3)
+
+Candidate entry points (from handoff, in priority order):
+  1. <entry 1>
+  2. <entry 2>
+  3. <entry 3>
+
+Recommend starting with #<N> because <reason>.
+What would you like to tackle first?
+```
+
+Pick the recommendation from the handoff's stated top entry point. If drift was detected, the recommendation may shift — say so explicitly.
+
+## Edge cases
+
+- **NEXT_SESSION.md older than 14 days**: Print `Handoff is N days old. Worth a /session-drift pass before trusting it.` and run `/session-drift` semantics inline (a fuller reality-vs-ledger reconcile, not just the verification commands).
+- **NEXT_SESSION.md exists but is empty or malformed**: Fall back to `UPDATES.md` tail. Print warning.
+- **No ledger, no UPDATES, no NEXT_SESSION**: This is a first session, not a catchup. Print `No prior session state found. This is a fresh start.` Don't run drift check.
+- **`--force` used at last wrap**: Surface the forced-wrap reason prominently. Forced wraps often hide unfinished business.
+- **Verification commands fail to run** (tool missing, auth expired): Don't silently skip. Print `Could not verify <command>: <error>. Resolve before relying on handoff.`
+
+## Anti-patterns
+
+- Do **not** start work before the drift check completes. The whole point is to catch drift *before* it compounds.
+- Do **not** treat the handoff as ground truth. The handoff is a *claim* about world state at the time of wrap. The verification commands corroborate it.
+- Do **not** silently update `NEXT_SESSION.md`. It is overwritten only by `/session-wrap` or `/session-checkpoint`, never by `/session-catchup`.
+- Do **not** dump the entire ledger or full `UPDATES.md` into the catchup output. Last entry + last 3 ADs is enough. The user can ask for more.

--- a/skills/session-loop/sub/checkpoint.md
+++ b/skills/session-loop/sub/checkpoint.md
@@ -1,0 +1,110 @@
+# `/session-checkpoint` — mid-session light save
+
+Quick state save when you need to step away for an hour or two — not stop for the day. Lighter than `/session-wrap`. Skips the safety gate but flags newly-crossed irreversible boundaries.
+
+## When to invoke
+
+- Stepping away for lunch / a meeting / a context switch within the same day.
+- A long-running task is paused but not done.
+- The session is at a natural pause point but not a natural *stop* point.
+- You want a recoverable bookmark in case the agent loses context or crashes.
+
+If you are actually stopping for the day, use `/session-wrap` instead. Checkpoint is the lighter cousin — its handoff is less complete and is meant to be consumed within hours, not days.
+
+## How it differs from `/session-wrap`
+
+| Aspect | `/session-wrap` | `/session-checkpoint` |
+| --- | --- | --- |
+| Safety gate (refuses on dirty work) | Yes | No (warn only) |
+| `UPDATES.md` append | Yes | No |
+| Ledger append | Yes (logs decisions) | No |
+| `NEXT_SESSION.md` overwrite | Yes | Yes |
+| Suggested commit | Yes | No |
+| Irreversible-boundary flag | Implicit (logged in ledger) | Explicit (loud warning) |
+
+The mental model: wrap is for handoffs across sessions. Checkpoint is for handoffs across hours within a session.
+
+## Procedure
+
+### Step 1: detect newly-crossed irreversible boundaries since last checkpoint
+
+This is the most important part. Checkpoint's job is to make sure you don't drift past a one-way door without noticing.
+
+Compare current state against the prior `NEXT_SESSION.md` snapshot (if any). Flag if any of these happened **since the last checkpoint or wrap**:
+
+- A cloud resource was *created* (`az create`, `aws create`, `gcloud create`, `kubectl apply` of a new namespaced resource).
+- A DNS record was changed.
+- A secret was rotated (`az keyvault secret set`, `aws secretsmanager update-secret`, `kubectl create secret`).
+- A database migration was run.
+- A `helm install` or `helm upgrade` succeeded.
+- A `terraform apply` succeeded.
+- A PR was merged (`gh pr merge`).
+- A package was published / image pushed.
+
+If any boundary crossed: print loudly **before** writing the checkpoint:
+
+```
+⚠ Irreversible boundary(ies) crossed since last save:
+  - <boundary 1>: <one-line detail>
+  - <boundary 2>: <one-line detail>
+
+These are not reversible by /session-catchup or /session-wrap. If you intend to record them as decisions, run /session-decide before stepping away.
+```
+
+Do not refuse — the user may have legitimately crossed the boundary on purpose. Just make sure they see it.
+
+### Step 2: collect minimal snapshot
+
+Build a snapshot. Smaller than wrap's — just enough to resume within the day:
+
+- Current git HEAD + branch.
+- `git status --porcelain` summary (count of modified/added/deleted files; do not list secrets-bearing filenames in full).
+- One-line "what I was doing" — extract from recent agent activity.
+- One-line "next step" — extract from recent task list or stated intent.
+- Up to 3 verification commands (smaller set than wrap; just the essentials).
+
+### Step 3: overwrite `NEXT_SESSION.md`
+
+Use the same template as wrap, but populate fewer fields. Required:
+
+- Snapshot table (with `Wrap kind: checkpoint`).
+- "What I was doing" (2–3 sentences).
+- "Where I stopped" (1–2 sentences).
+- Top 1 candidate entry point (not 3 — checkpoint is shorter horizon).
+- Verification commands (with current outputs).
+
+Skip:
+
+- Top 3 entry points (use top 1 only).
+- Open threads section (too heavy for an hour-long pause).
+- Recommended start reasoning (just point at entry #1).
+
+### Step 4: do NOT commit
+
+Checkpoint does not commit. Why: an hour later you want to keep working on the same dirty state, and a commit-then-amend dance is friction. The next `/session-wrap` will commit `NEXT_SESSION.md` along with its own artifacts if the user confirms.
+
+Print to user:
+
+```
+Checkpoint saved.
+  Last action:   <one-line>
+  Next step:     <one-line>
+  Verify with:   <command 1>; <command 2>
+
+To resume: /session-catchup (or just keep working).
+```
+
+## Edge cases
+
+- **No prior `NEXT_SESSION.md`**: this is the first save. Skip boundary detection (no baseline to compare). Just write the file.
+- **Prior `NEXT_SESSION.md` is a wrap, not a checkpoint**: that's fine. Treat it as the baseline for boundary detection.
+- **Rapid re-checkpointing** (multiple checkpoints within a few minutes): allowed but probably wasteful. After the third one in 10 minutes, print `You've checkpointed 3 times in 10 minutes. Are you actually pausing, or just nervous? Consider /session-wrap if stopping.`
+- **Boundary detected but user explains it**: e.g. user says "yes I just rotated that secret, it was intentional". Note their explanation in the "Notes for next session" section of `NEXT_SESSION.md`. Still write the checkpoint.
+- **Long gap since last save** (>1 day): warn `Last save was N days ago — checkpoint isn't the right tool for that gap. Consider /session-wrap.`
+
+## Anti-patterns
+
+- Do **not** use checkpoint as a substitute for wrap at end of day. Wrap exists for a reason — the safety gate.
+- Do **not** silently overwrite a wrap-kind `NEXT_SESSION.md` with a checkpoint-kind one and lose the wrap's richer fields. If overwriting a wrap, *append* the checkpoint as a sub-section under the wrap, or print warning before overwrite.
+- Do **not** log decisions to the ledger from checkpoint. That is `/session-decide`'s job. Checkpoint is narrative-only.
+- Do **not** run probes or drift checks. Checkpoint is meant to be cheap and fast. If the user wants to verify state, they invoke `/session-drift` separately.

--- a/skills/session-loop/sub/compact-check.md
+++ b/skills/session-loop/sub/compact-check.md
@@ -1,0 +1,70 @@
+# `/session-compact-check` — pre-compaction state persistence
+
+Self-assess whether to compact context window at a task boundary, persisting carry-forward state to project artifacts before any compaction.
+
+Migrated from `~/.claude/commands/compact-check.md` into the session-loop suite so it can share the `NEXT_SESSION.md` / ledger artifact contract with the rest of the pause/resume flows.
+
+## When to invoke
+
+- At a clean task boundary, when context pressure is high.
+- User says "compact now", "context is getting heavy", "save state and trim".
+- Before starting a large or uncertain next task.
+
+Do not invoke mid-task. The point is to compact only at clean boundaries.
+
+## Procedure
+
+### 1. Assess pressure
+
+- Estimate remaining context budget (rough %).
+- Identify whether current context is dominated by completed-task noise (tool outputs, file dumps, dead ends) vs live signal (decisions, open threads, constraints).
+
+### 2. Decide compaction need
+
+Compact ONLY if BOTH true:
+
+(a) >60% of remaining budget consumed, OR next task is large/uncertain.
+(b) At a clean task boundary — current task marked done in task metadata, no open sub-threads.
+
+Otherwise skip — proceed to next task.
+
+### 3. Pre-compact persist (mandatory before any compaction)
+
+Write to carry-forward artifacts. Prefer `NEXT_SESSION.md` as the primary destination, since the rest of the session-loop suite already consumes it. If `NEXT_SESSION.md` does not exist in this project, write to the agent's native task metadata.
+
+For `NEXT_SESSION.md` writes via `/session-compact-check`: update only the **"Open threads"** and **"Notes for next session"** sections. Do not overwrite the snapshot or verification commands — those are owned by `/session-wrap` and `/session-checkpoint`. If those sections are missing entirely (no prior wrap/checkpoint), write a minimal `NEXT_SESSION.md` with just open threads and a note `Snapshot pending — run /session-checkpoint or /session-wrap to fill.`
+
+Persist:
+
+- **Completed task**: outcome, key files touched, decisions made, non-obvious gotchas discovered.
+- **Carry-forward state**: anything next task depends on that is NOT recoverable by re-reading code/artifacts (e.g. user preferences expressed mid-session, ruled-out approaches with reasons, ambient constraints).
+- **Open questions / deferred items**: log to `NEXT_SESSION.md` "Open threads" section. These will also surface in `/session-open-loops`.
+- **Reconciliation**: if a canonical state artifact exists (ledger, README, pinned config), diff its top-level summary fields against decisions actually made this session. List divergences explicitly in carry-forward. Do NOT silently rewrite the summary — surface the conflict so the user can ratify (via `/session-decide`).
+
+Verify artifact written before compacting.
+
+### 4. Post-compact rehydrate
+
+First action after compaction: re-read carry-forward artifact (`NEXT_SESSION.md` and/or task metadata) + relevant code files. Do not rely on summarized memory of pre-compact state for anything load-bearing.
+
+### 5. Report
+
+State: `Compacted: yes/no. Reason: <one line>.` then proceed.
+
+## Rule
+
+When uncertain whether context is recoverable from artifacts/code, do NOT compact. Bias toward keeping context.
+
+## Edge cases
+
+- **Decision discovered during reconciliation that wasn't logged**: do not auto-log it. Surface as `Potential AD: <one-line>. Consider /session-decide before compacting.` Let the user decide.
+- **No clean boundary** (current task in_progress): refuse to compact. Print `Task in progress — finish or pause it before /session-compact-check.`
+- **Project has no `NEXT_SESSION.md`**: fall back to agent's native task metadata. Persist there. Note in output that NEXT_SESSION.md doesn't exist yet (user can run `/session-checkpoint` to bootstrap one).
+- **Compaction would lose distinctive context that hasn't been recorded anywhere** (e.g. nuanced user preferences expressed mid-session): refuse to compact until those are persisted. Surface what would be lost.
+
+## Anti-patterns
+
+- Do **not** compact when uncertain. Cost of keeping context = slower next response. Cost of losing context = redoing work, repeating questions, making wrong decisions.
+- Do **not** overwrite `NEXT_SESSION.md`'s snapshot / verification commands from compact-check. Those belong to wrap/checkpoint.
+- Do **not** log decisions to the ledger from compact-check. Surface the candidate, route to `/session-decide`.
+- Do **not** report success without verifying the persist write actually landed.

--- a/skills/session-loop/sub/decide.md
+++ b/skills/session-loop/sub/decide.md
@@ -1,0 +1,117 @@
+# `/session-decide` — append ADR-style decision
+
+Capture a decision made in conversation as a structured, append-only entry in the project's ledger. Forces the user to articulate the *why* and the *what-was-rejected* so future-them (or a teammate) can re-evaluate the decision later without re-litigating from scratch.
+
+## When to invoke
+
+- User explicitly says "log this", "record this decision", "add an ADR".
+- A non-trivial choice was just made in conversation and is at risk of being forgotten or revisited:
+  - Choosing one architecture over another.
+  - Picking a tool/library/region/SKU.
+  - Setting a scope boundary ("only X migrates, not Y").
+  - Locking in a workflow contract ("we always do X before Y").
+- A decision *supersedes* a prior decision and the prior one is in the ledger — record the supersession explicitly.
+
+If the user is just thinking out loud, do not invoke. Decisions worth logging are ones the user has *committed to* and that have a non-trivial blast radius.
+
+## Procedure
+
+### Step 1: ledger discovery
+
+Find the project's append-only ledger using the discovery order from the umbrella `SKILL.md`:
+
+1. `DECISIONS.md`
+2. `MIGRATION_LEDGER.md`
+3. `PROJECT_LOG.md`
+4. `ADR.md` or `docs/adr/` (if a directory, write a new file `docs/adr/ADR-NNN-<slug>.md` instead of appending to a single file)
+5. Heuristic match (any top-level `*.md` whose first 50 lines mention "append" and "ledger"/"ADR"/"decision")
+
+If none found: default to `DECISIONS.md` in project root. Create the file with a one-line header:
+
+```markdown
+# Decisions
+
+Append-only ADR log. Never retro-edit; supersede with new dated entries.
+```
+
+Print which ledger was chosen so the user can correct on the first run.
+
+### Step 2: collect required fields
+
+Use the template at `templates/DECISION.md`. Required fields, in order:
+
+1. **AD number** — sequential. Find the last `AD-NNN` in the existing ledger; this one is NNN+1. If first decision, `AD-001`.
+2. **Date** — today's date in `YYYY-MM-DD`.
+3. **Title** — one-line. Verb phrase. ("Use Cognito Token Bridge for interim auth", not "Auth strategy".)
+4. **Context** — what triggered this decision? 2–4 sentences. The forcing function.
+5. **Decision** — what was chosen. State affirmatively.
+6. **Alternatives rejected** — at least one. For each: name + one-line reason it was rejected. If "no alternatives considered", record that too — future-you will want to know.
+7. **Supersedes** — prior AD-NNN if any. "None" if this is a fresh decision.
+8. **Blast radius** — services, files, resources, teams affected.
+9. **Reversibility** — `reversible` / `partially-reversible` / `irreversible`. One sentence on why.
+10. **Author** — agent name + user name if known.
+
+If the user has provided some of these in conversation already, fill them in. For missing required fields, ask the user — one question per field, not a wall of questions:
+
+```
+What's the forcing function for this decision? (Context — 2-4 sentences)
+```
+
+Don't proceed to append until all required fields are filled. The point of `/session-decide` is to extract the information the user is about to forget.
+
+### Step 3: append to ledger
+
+For a single-file ledger: append at the **bottom**. Append-only ledgers grow chronologically; do not insert at the top. (This is different from `UPDATES.md` which is newest-on-top.)
+
+For an `adr/` directory: create a new file `ADR-NNN-<slug>.md`.
+
+Use exactly the template at `templates/DECISION.md`. Do not invent fields. Do not omit fields.
+
+### Step 4: cross-link if superseding
+
+If `Supersedes: AD-<prior>`: do **NOT** edit the prior AD. Append-only means append-only. Instead, in the new AD's `Context` section, mention the supersession explicitly so the reader of the prior AD who searches for its ID finds the new one:
+
+```markdown
+**Context**: AD-007 is being superseded. The original decision to use X
+turned out to be wrong because Y. This AD records the new choice.
+```
+
+A future reader of AD-007 will not see a backlink (impossible without retro-edit). They have two ways to find AD-NNN:
+
+- Read forward chronologically.
+- Search the ledger for `Supersedes: AD-007`.
+
+This is acceptable — append-only purity is worth the modest search cost.
+
+### Step 5: confirm
+
+Print to user:
+
+```
+Decision recorded:
+  AD-NNN · YYYY-MM-DD · <title>
+  Ledger: <path>
+  Supersedes: <AD-NNN or "none">
+
+Consider committing: git add <ledger>; git commit -m "decide: AD-NNN <title>"
+```
+
+`/session-decide` does **not** auto-commit. (Different from `/session-wrap`, which may auto-commit its own artifacts.) Reason: decisions often happen mid-task while user-owned files are dirty. Auto-committing the ledger while user code is half-written creates a commit graph that interleaves decision-log commits with code commits in a confusing way. Suggest the commit; let the user decide when to run it.
+
+If the user wants auto-commit: pass `--commit` flag. With `--commit`, run only `git add <ledger-path>` and `git commit -m "decide: AD-NNN <title>"` — explicit path, no `git add .`.
+
+## Edge cases
+
+- **Multiple decisions in one conversation**: process one at a time. Each gets its own AD number, its own `/session-decide` invocation. Don't bundle.
+- **User describes the decision but it's not actually final** ("I'm thinking we should..."): do not log. Ask `Is this a finalized decision, or still under consideration? Decisions in the ledger should be ones you're committing to.`
+- **Decision contradicts ledger but isn't framed as supersession**: surface the contradiction. `AD-007 says X. This new decision implies Y, which contradicts. Should this be recorded as 'Supersedes: AD-007'?`
+- **AD numbering collision** (two agents racing on the same ledger): re-read the ledger immediately before append; recompute next AD number. If race detected (someone else appended AD-NNN between read and write), retry with NNN+1.
+- **No ledger directory exists yet** and project uses `docs/adr/` style: create the directory before the first file write.
+- **User wants to delete an AD**: refuse. Append-only. If the decision was wrong, the user records a new AD that supersedes it. The wrong one stays as historical record. Print `Append-only ledgers don't support deletion. Record a new AD that supersedes AD-NNN instead.`
+
+## Anti-patterns
+
+- Do **not** edit prior ADs. Ever. The whole value of append-only is that the historical record is intact.
+- Do **not** log every micro-decision. ADs are for choices with non-trivial blast radius. Function-naming, variable choices, formatting preferences — those are not ADs.
+- Do **not** bundle multiple decisions into one AD. One decision per AD, even if they were made in the same conversation. Future search benefits from atomic entries.
+- Do **not** skip the "alternatives rejected" field. Even "no alternatives considered" is informative — it tells future-you that the decision was reached without deliberation, which may be a reason to re-evaluate.

--- a/skills/session-loop/sub/drift.md
+++ b/skills/session-loop/sub/drift.md
@@ -1,0 +1,134 @@
+# `/session-drift` — reality vs ledger reconcile
+
+Standalone sanity check. Runs anytime, not only at `/session-catchup`. Compares what the project's ledger and handoff *claim* about world state against what is actually true right now.
+
+## When to invoke
+
+- Before a risky operation: "Check the world before I run `helm upgrade`."
+- Sporadic confidence check after several days of work: "Is the ledger still accurate?"
+- After a known out-of-band event: someone else pushed, a deployment was rolled back manually, a teammate restarted a pod.
+- Before `/session-decide` — verify the premise of the decision still holds.
+
+`/session-drift` is intentionally not the same as `/session-catchup`. Catchup is the start-of-session ritual with proposing-next-move on the end. Drift is just the reconcile — no next-move proposal, no handoff reading.
+
+## What it does
+
+1. **Collect claims** from project artifacts.
+2. **Probe reality** with the corresponding commands.
+3. **Diff** claims vs reality.
+4. **Surface** divergences, classified as expected vs concerning.
+
+That is the entire scope. Drift does not fix anything, does not write anything, does not commit anything. It is read-only.
+
+## Procedure
+
+### Step 1: collect claims
+
+Read claims in this order, stopping at first source that yields any:
+
+1. **`NEXT_SESSION.md` verification commands** — if present and ≤14 days old. Each command-plus-output pair is a claim.
+2. **Most recent `UPDATES.md` "State at wrap" section** — narrative claims about what is deployed, what is configured, what is running.
+3. **Last 3 ADs from the discovered ledger** — for each, the "Blast radius" field names artifacts that should reflect the decision.
+
+If none of these exist: print `No claims to verify — no ledger or handoff present. /session-drift requires at least one artifact to reconcile against.` Exit.
+
+### Step 2: probe reality
+
+For each verification command from step 1: re-run it. Capture output.
+
+For each ledger-derived claim (last 3 ADs): if the AD names a specific resource (`AKS namespace foo`, `helm release bar`, `subscription baz`), probe it directly. Common probes:
+
+| Claim type | Probe command |
+| --- | --- |
+| Git HEAD or branch | `git rev-parse HEAD`, `git status -sb` |
+| Helm release deployed | `helm list -n <ns>` |
+| Kubernetes namespace exists | `kubectl get ns <ns>` |
+| Kubernetes resource deployed | `kubectl -n <ns> get <kind> <name> -o jsonpath='{.status}'` |
+| Azure resource exists | `az resource show --ids <id>` or `az resource list -g <rg>` |
+| Cloudflare DNS record | `dig <fqdn>` and compare expected target |
+| GitHub PR state | `gh pr view <N> --json state,mergeable` |
+| Terraform state | `terraform plan -detailed-exitcode` (exit 2 = drift) |
+| Docker image tag pushed | `gh api repos/<o>/<r>/actions/runs?event=push&per_page=1` or registry-specific |
+
+Skip probes whose tools are not installed. List the skipped ones in the output — never silently omit.
+
+### Step 3: classify divergences
+
+For each diff, classify:
+
+- **No divergence** — claim and reality match. Don't list these by default; show count only.
+- **Expected drift** — natural change since the claim was recorded:
+  - Pod names changed (restart-driven; pod *count* unchanged).
+  - Log timestamps newer.
+  - `kubectl get` resource versions higher.
+  - Git ahead of `origin` by some commits (if user has been working).
+- **Concerning drift** — material change requiring user decision:
+  - Git HEAD changed *backward* (someone reset).
+  - Branch diverged from `origin` (both ahead and behind).
+  - Pod count or replica count changed.
+  - Helm release status changed (`deployed` → `failed`, `pending-upgrade`, `superseded`).
+  - Resource that ledger claims exists is missing (or vice versa).
+  - Terraform plan exits with code 2 (drift detected).
+  - PR state changed (`open` → `merged` / `closed`).
+
+When unsure, classify as concerning. Bias toward surfacing.
+
+### Step 4: output
+
+Print in this order:
+
+```
+═══ Drift check — <timestamp> ═══
+
+Sources consulted:
+  ✓ NEXT_SESSION.md (handoff from <date>, N days ago)
+  ✓ UPDATES.md (last entry <date>)
+  ✓ MIGRATION_LEDGER.md (last 3 ADs: AD-NNN, AD-NNN, AD-NNN)
+
+Probes run: <N>  | matched: <N>  | expected drift: <N>  | concerning: <N>  | skipped (tool missing): <N>
+
+Skipped probes (tool unavailable):
+  - <probe>: <missing tool>
+
+Expected drift (informational):
+  - <one-line per item>
+
+⚠ Concerning drift:
+
+  <Item 1>
+    Claim:    <from ledger / handoff>
+    Reality:  <from probe>
+    Probe:    `<command>`
+    Likely:   <one-line interpretation>
+    Action:   <one-line suggested response>
+
+  <Item 2>
+    ...
+
+Recommendation:
+  <one of:>
+  - World matches claims. Safe to proceed.
+  - Minor expected drift only — proceed but be aware of <item>.
+  - Concerning divergence — DO NOT proceed with risky operations until reconciled. Suggested order: (1) clarify <X> with team, (2) /session-decide if a new decision is needed, (3) re-run /session-drift.
+```
+
+### Step 5: do not write
+
+Drift never writes. Not to `NEXT_SESSION.md`, not to the ledger, not anywhere. If the user wants to record a divergence-driven decision, that is `/session-decide`. If they want to update the handoff after reconciling, that is `/session-wrap` or `/session-checkpoint`.
+
+The one exception: if drift is invoked with `--snapshot` flag, write the probe output (without classification) to `.session-drift/<timestamp>.txt` for later inspection. This is opt-in only — not the default.
+
+## Edge cases
+
+- **No probes can run** (no `kubectl`, `az`, `gh`, `helm` installed): print `No probes available — install at least one of the cloud CLIs to run drift checks meaningfully.` Exit without classification.
+- **Probe times out**: cap each probe at 30s. On timeout, mark as `inconclusive` (not "concerning") and continue.
+- **Auth expired** (`az login` token expired, `gh auth` lapsed, `kubectl` context broken): print the auth error and the specific renewal command. Do not try to refresh auth automatically.
+- **Ledger claims unparseable resource ID** (free-text claim like "we deployed it"): skip probing, note as `claim too vague to probe — consider adding explicit resource IDs to future AD blast-radius`.
+- **Handoff older than 30 days**: print warning at the top: `Handoff is N days old. Expected drift will be high. Focus on Concerning section.`
+
+## Anti-patterns
+
+- Do **not** try to "fix" the drift by editing ledger or handoff files. Surface only — the user decides.
+- Do **not** auto-run `/session-wrap` after drift to "record what's true now". That is a forward decision the user must make.
+- Do **not** suppress probes that exit non-zero. Non-zero is often the *interesting* signal (resource missing, auth expired).
+- Do **not** chain drift into other sub-flows. Each is invoked deliberately.

--- a/skills/session-loop/sub/open-loops.md
+++ b/skills/session-loop/sub/open-loops.md
@@ -1,0 +1,123 @@
+# `/session-open-loops` — scan unresolved threads
+
+Aggregate every "still open" thread across the project's artifacts into a single ranked list. Use before `/session-wrap` to make sure nothing important is being left silent, or anytime you want to know "what's still on my plate".
+
+## When to invoke
+
+- Before `/session-wrap` — make sure the wrap's "Open threads" section captures everything.
+- During a working session, when feeling lost: "what was I supposed to be doing this week?"
+- After `/session-catchup` if the catchup output felt incomplete.
+- Periodically as project hygiene — open loops accumulate silently.
+
+## What counts as an open loop
+
+Aggregate from these sources:
+
+1. **`NEXT_SESSION.md`** — `Open threads (carry-forward)`, `Blockers / unanswered questions`, top entry points that weren't picked up.
+2. **`UPDATES.md`** — most recent N entries' `Open threads` sections (default N=5).
+3. **Ledger (`DECISIONS.md` / `MIGRATION_LEDGER.md` / discovered)** — any AD with `Reversibility: partially-reversible` or `irreversible` whose follow-up wasn't logged in a later AD. Also any AD whose Context references a "phase 2" / "later" / "TODO".
+4. **In-repo TODO markers** — `TODO`, `FIXME`, `XXX`, `HACK`, `revisit`, `tech-debt`, dated by commit. Filter to ones either authored by the current user OR explicitly mentioning the current project's scope.
+5. **Open PRs assigned to the user** — `gh pr list --author @me --state open` (and `--review-requested @me`).
+6. **Issues with the user's label** — `gh issue list --assignee @me --state open` if `gh` available and the project has a recognizable repo.
+7. **Agent task list** — any tasks still in `pending` or `in_progress` state.
+
+Each source contributes "threads". Deduplicate threads that appear in multiple sources (same wording, same target) — show once with all sources cited.
+
+## Procedure
+
+### Step 1: enumerate threads from each source
+
+For each source, list its open items. Cap at reasonable limits (don't dump 200 TODO markers; cap at 50 for in-repo markers, keep the most recent).
+
+### Step 2: rank by urgency / blast radius
+
+Use a simple scoring rubric:
+
+| Signal | Weight |
+| --- | --- |
+| Blocker (named blocker in `NEXT_SESSION.md`) | 10 |
+| Names an irreversible AD that lacks follow-up | 8 |
+| Open PR awaiting user review | 7 |
+| Open PR authored by user with stale CI | 6 |
+| Top entry point from prior handoff not yet completed | 5 |
+| Open issue assigned to user | 4 |
+| Carry-forward thread from prior `UPDATES.md` entry | 3 |
+| Pending agent task | 3 |
+| TODO marker authored by user, dated >30 days | 2 |
+| FIXME / XXX in code | 2 |
+| Other TODO markers | 1 |
+
+Sort threads by score descending. Within same score, sort by recency (newer first).
+
+This is a rough rubric — adjust if the user asks. The point is to surface what matters first, not to be precisely correct.
+
+### Step 3: output
+
+```
+═══ Open loops — <timestamp> ═══
+
+Sources scanned:
+  ✓ NEXT_SESSION.md (handoff from <date>)
+  ✓ UPDATES.md (last 5 entries)
+  ✓ <ledger> (last N ADs scanned)
+  ✓ In-repo TODO markers (<count> found, top 10 shown)
+  ✓ gh PRs (assignee=@me, review-requested=@me)
+  ✓ Agent tasks (pending + in_progress)
+
+Total open loops: <N>
+
+═══ Top priority ═══
+
+1. [BLOCKER] <one-line>
+   Source: NEXT_SESSION.md
+   Score: 10
+
+2. [PR REVIEW] <pr title> (#NN)
+   gh pr view NN
+   Score: 7
+
+3. [AD FOLLOW-UP] AD-007 (Cognito Token Bridge) — phase 2 (Keycloak cutover) not yet logged
+   Source: <ledger>
+   Score: 8
+
+═══ Medium ═══
+
+4. <one-line>
+5. <one-line>
+...
+
+═══ Low (FYI) ═══
+
+N. <one-line>
+N+1. <one-line>
+...
+
+Recommendation:
+  Tackle items 1-3 next. Items in "Low" are background — surface them again next /session-open-loops scan.
+```
+
+If a thread cites the ledger or `NEXT_SESSION.md`, include the AD-NNN reference inline so the user can jump.
+
+### Step 4: do not write
+
+`/session-open-loops` is read-only — same as `/session-drift`. It does not modify any artifact. If the user wants to close a loop, they do so via:
+
+- `/session-decide` (record a decision that resolves it)
+- `/session-wrap` (carry it forward explicitly into the next handoff)
+- Doing the work and committing
+- Closing the PR/issue manually
+
+## Edge cases
+
+- **No artifacts at all**: print `No sources to scan. /session-open-loops needs at least one of: NEXT_SESSION.md, UPDATES.md, or a ledger.` Exit.
+- **Massive TODO count** (thousands of in-repo markers in a large repo): cap aggressively. Default to TODO markers authored by current user in the last 90 days. Print the total count so the user knows the rest exist.
+- **`gh` not available**: skip PR/issue sources, note in output.
+- **Same thread cited in multiple sources**: list once with all citations.
+- **Threads phrased ambiguously** ("revisit later", "TBD", "TODO: rewrite this"): include but mark as low-confidence. The user might want to re-articulate them via `/session-decide`.
+
+## Anti-patterns
+
+- Do **not** auto-close anything. Open loops close when the user resolves them — via decisions, work, or explicit dismissal.
+- Do **not** flatten the ranking to a single number with no rationale. Show the score *and* the reason (BLOCKER / PR REVIEW / AD FOLLOW-UP / etc.) so the user can disagree.
+- Do **not** dedupe too aggressively. If a thread appears in both `NEXT_SESSION.md` and a `UPDATES.md` entry, that's evidence it's been open for a while — flag the persistence, don't hide it.
+- Do **not** include "open loops" that are actually just routine project work. The threshold is "this was deferred or blocked", not "this is on the roadmap".

--- a/skills/session-loop/sub/wrap.md
+++ b/skills/session-loop/sub/wrap.md
@@ -1,0 +1,197 @@
+# `/session-wrap` — end-of-session handoff
+
+Two-phase procedure: **safety gate** first, **handoff write** second. Refuse to write a handoff if the world is in a state that cannot be safely paused.
+
+## When to invoke
+
+- User says "let's stop here", "wrap up", "end of session", "I'm done for today".
+- User signals context switch ("I'll pick this up tomorrow").
+- Long-running task hits a natural boundary and user confirms stop.
+
+## Action scope (read this before doing anything)
+
+`/session-wrap` has two distinct authorities:
+
+- **Over user work** (source code, infra files, app config): **suggest only, never auto-fix**. If a gate fails because of user work, list the problem and stop. The user resolves it (or passes `--force` with a reason). The skill does not stage, commit, revert, or modify user-owned files.
+- **Over its own artifacts** (`UPDATES.md`, ledger entries it writes, `NEXT_SESSION.md`): full authority. May write, overwrite, and commit. Never stages anything outside this artifact set. Never runs `git add .` or `git add -A`.
+
+Keep this boundary strict. If a future change asks the skill to fix user work as a convenience, refuse — the value of the gate is that it forces the user to see and decide.
+
+## Phase 1 — stop-safety gate
+
+Run all checks. Surface every failure as a discrete item the user must resolve (or explicitly waive with `--force`). Do **not** proceed to phase 2 until all gates pass or `--force` is given.
+
+**Suggest, don't fix.** Every gate failure is a *recommendation* to the user. Do not run `git add`, `git stash`, `kubectl rollout`, `helm rollback`, or any other remediating command on the user's behalf — even if the fix looks obvious. The user decides whether to clean up or `--force`.
+
+### Gate checks
+
+1. **Git working tree**
+   - Run `git status --porcelain` and `git status -sb`.
+   - **Fail if**: uncommitted changes touch files matching any of: `*.env*`, `*secret*`, `*credential*`, `*.pem`, `*.key`, `*token*`, `kubeconfig*`. These are dangerous to leave loose between sessions.
+   - **Warn if**: any uncommitted changes exist at all. Not a hard fail, but list the diff summary.
+   - **Fail if**: branch is detached HEAD and there are uncommitted changes.
+   - **Warn if**: branch is ahead of `origin/<branch>` by more than 0 commits. Suggest push.
+
+2. **Infrastructure-as-code drift**
+   - If `terraform/` or `*.tf` present at repo root or in immediate subdirs: check for `terraform.tfstate.backup` newer than `terraform.tfstate` (mid-apply marker) — **fail**.
+   - If `*.bicep` or `bicepconfig.json` present and last `az deployment` in shell history was less than 5 minutes ago: **warn** — confirm deployment completed.
+   - If `Chart.yaml` or `helm/` present: check for active `helm` processes (`pgrep -laf helm` if available); if any release is `pending-upgrade` or `pending-install` (when `kubectl` and `helm` both available): **fail**.
+
+3. **Cloud resources potentially orphaned**
+   - If the conversation explicitly created cloud resources this session (look for `az`/`aws`/`gcloud` create commands in conversation context), list them and ask the user to confirm they should remain. Do not auto-fail — agents cannot reliably distinguish intentional from orphaned.
+
+4. **Open agent-managed tasks**
+   - If TaskList shows tasks in `in_progress` state: list them and **fail**. Tasks must be moved to `completed` or `cancelled` before wrap.
+
+5. **Half-baked file edits**
+   - Scan recently edited files (this session) for markers: `// TODO(this-session)`, `// XXX`, `<<<<<<< HEAD`, conflict markers. **Fail** on conflict markers, **warn** on TODO/XXX.
+
+### Gate output
+
+Print a table:
+
+```
+| Gate                          | Status | Detail                                  |
+|-------------------------------|--------|-----------------------------------------|
+| Git working tree              | PASS   |                                         |
+| Sensitive uncommitted files   | FAIL   | .env.local has unstaged changes         |
+| Helm release state            | PASS   |                                         |
+| ...                           | ...    | ...                                     |
+```
+
+If any FAIL: stop here. Ask user to clean up, or pass `--force` to override (with a one-line reason that gets logged into the handoff).
+
+## Phase 2 — handoff write
+
+Only runs if phase 1 passed (or `--force`).
+
+### Step 1: capture verification commands
+
+Build a list of commands future-you will rerun on `/session-catchup` to confirm the world still matches. Pick the smallest set that covers what was touched this session. Examples:
+
+- `git rev-parse HEAD` + `git status --porcelain` (always)
+- `gh pr view <N> --json state,mergeable` (if a PR was opened this session)
+- `kubectl -n <ns> get pods` (if AKS/EKS pods were touched)
+- `az resource list --resource-group <rg> --query "[].{name:name,type:type}" -o table` (if Azure resources were touched)
+- `terraform plan -detailed-exitcode` (if Terraform was applied)
+- `helm list -n <ns>` (if helm was used)
+
+Record the exact command and its output **right now**, so `/session-catchup` can diff against current reality.
+
+### Step 2: append to `UPDATES.md`
+
+Insert a dated entry at the **top** of `UPDATES.md` (newest-first convention). Template:
+
+```markdown
+## YYYY-MM-DD — <one-line summary of session>
+
+### What
+
+<2–5 sentence narrative of what was actually done this session.>
+
+### Why
+
+<Motivation. Skip if same as the broader project's stated motivation.>
+
+### State at wrap
+
+<Where things stand. Don't claim more than is true. If a deploy failed mid-way, say so.>
+
+### Open threads (carry-forward)
+
+- <Thread 1: what's unresolved, who/what blocks it.>
+- <Thread 2: ...>
+```
+
+If `UPDATES.md` does not exist, create it with a one-line header explaining the append protocol, then add the entry.
+
+### Step 3: append to ledger (`DECISIONS.md` / `MIGRATION_LEDGER.md` / discovered)
+
+For each **decision made this session that wasn't already logged**, append an entry:
+
+```markdown
+## AD-NNN · YYYY-MM-DD · <decision title>
+
+**Context**: <what triggered this decision>
+**Decision**: <what we chose>
+**Alternatives rejected**: <what we considered and why we didn't pick it>
+**Supersedes**: <prior AD-NNN if any, else "none">
+**Blast radius**: <files/services/resources affected>
+**Reversibility**: <reversible | partially | irreversible — and why>
+```
+
+Number ADs sequentially from the last `AD-NNN` in the file. If none exist, start at `AD-001`.
+
+**Do not retro-edit prior ADs.** If this session changed a prior decision, the new AD has `Supersedes: AD-<prior>` and the prior entry stays verbatim.
+
+### Step 4: write `NEXT_SESSION.md`
+
+**Overwrite** (not append). This file is ephemeral handoff state — the next `/session-wrap` or `/session-checkpoint` overwrites it. Use the template at `templates/NEXT_SESSION.md`. Fill every section.
+
+### Step 5: optionally commit handoff artifacts
+
+Wrap *may* commit its own artifacts — and only its own. The committable set is the exact files written by steps 2–4:
+
+- `UPDATES.md`
+- the chosen ledger file (`DECISIONS.md`, `MIGRATION_LEDGER.md`, etc.)
+- `NEXT_SESSION.md`
+
+Behavior:
+
+- Default: prompt the user — `Commit handoff artifacts? [y/N]`. Default answer is `N`. If the user says no, skip the commit; they can commit manually later.
+- `--auto-commit`: skip the prompt, commit immediately.
+- `--no-commit`: skip the prompt, do not commit. (Useful for CI / non-interactive runs.)
+
+When committing, use **explicit path adds** — never `git add .`, never `git add -A`:
+
+```bash
+git add UPDATES.md "<ledger-path>" NEXT_SESSION.md
+git commit -m "chore(session): wrap YYYY-MM-DD"
+```
+
+If `NEXT_SESSION.md` is in `.gitignore` (some projects prefer it untracked since it is ephemeral): omit it from the `git add`. The commit still proceeds for the other two files. Print a note: `NEXT_SESSION.md is gitignored — leaving uncommitted.`
+
+If any of the three files are unchanged (rare but possible — e.g. a re-run wrap that produces identical narrative), skip the commit and print `No artifact changes to commit.`
+
+**Hard limits**:
+- Never stage files outside the committable set.
+- Never run `git push`. Wrap is local-only.
+- Never amend a prior commit.
+- Never run `git stash` to "set aside" dirty user work — phase 1 already refused on dirty state, so this should not arise.
+
+### Step 6: confirm and exit
+
+Print to the user:
+
+```
+Handoff written:
+- UPDATES.md          (+1 entry)
+- <ledger>            (+<N> AD entries)
+- NEXT_SESSION.md     (overwritten)
+
+Commit:
+  <sha if committed | "skipped (user declined)" | "skipped (--no-commit)" | "no changes">
+
+Verification commands for next session:
+  <list>
+
+Resume command:
+  /session-catchup
+```
+
+That is the entire output. No additional commentary — the artifacts speak for themselves.
+
+## Edge cases
+
+- **No project ledger at all**: Default to creating `DECISIONS.md` in the project root. Report what was created.
+- **Multiple candidate ledgers**: First match by the discovery order in the umbrella `SKILL.md`. Report the choice; user can correct on re-run.
+- **`--force` with no reason**: Refuse. Force requires a one-line justification that gets prepended to the `UPDATES.md` entry as `> ⚠ Forced wrap: <reason>`.
+- **Empty session** (no commits, no edits, no decisions): Skip the handoff write entirely. Print `Nothing to wrap — no state change this session.`
+- **Re-run of `/session-wrap` in same session**: Detect by checking if `NEXT_SESSION.md` mtime is within the last 10 minutes AND its content already reflects the current `git rev-parse HEAD`. If so, print `Already wrapped at <time>. No change.` and exit.
+
+## Anti-patterns
+
+- Do **not** summarize the entire conversation into `UPDATES.md`. Five sentences, not fifty.
+- Do **not** auto-`git push` or auto-merge. Wrap is a *recording* step, not a *publishing* step.
+- Do **not** silently rewrite the ledger summary if this session contradicts a prior decision. Append a new AD that supersedes; the contradiction is the point.
+- Do **not** skip phase 1 even when the user is in a hurry. The whole value of `/session-wrap` is the gate.

--- a/skills/session-loop/templates/DECISION.md
+++ b/skills/session-loop/templates/DECISION.md
@@ -1,0 +1,33 @@
+<!--
+DECISION.md — ADR entry template.
+
+Consumed by /session-decide. Append entries (do NOT retro-edit prior ones) to the project's discovered ledger (DECISIONS.md, MIGRATION_LEDGER.md, etc.) OR write a new file under docs/adr/ named ADR-NNN-<slug>.md.
+
+Append-only. If a decision turns out to be wrong, record a new AD with `Supersedes: AD-<prior>`. The prior entry stays verbatim.
+-->
+
+## AD-NNN · YYYY-MM-DD · <one-line decision title, verb-phrase>
+
+**Context**: <2–4 sentences. What was the forcing function? What problem or constraint triggered this decision? If this AD supersedes a prior one, mention the prior AD-NNN here and why the prior decision turned out to be insufficient.>
+
+**Decision**: <What was chosen. State affirmatively in one or two sentences. "We will X." Not "We are thinking about X" or "We probably want X".>
+
+**Alternatives rejected**:
+- **<Alternative 1>** — <one-line reason it was rejected>
+- **<Alternative 2>** — <one-line reason it was rejected>
+
+(If no alternatives were considered: record that explicitly — `**Alternatives rejected**: None considered. Decision made under time pressure / without deliberation.` This is informative for future re-evaluation.)
+
+**Supersedes**: <AD-NNN of the prior decision being superseded, or `None` if this is a fresh decision>
+
+**Blast radius**:
+- Services / repos: <list>
+- Files: <list, if specific>
+- Resources: <cloud resource IDs, helm releases, etc. — be specific, not "stuff in our cluster">
+- Teams: <who is affected operationally>
+
+**Reversibility**: <`reversible` | `partially-reversible` | `irreversible`> — <one-sentence explanation. E.g. "Reversible by re-running migration with rollback flag." Or "Irreversible: production data has been deleted under this schema change.">
+
+**Author**: <agent name + version> · <user name if known>
+
+---

--- a/skills/session-loop/templates/NEXT_SESSION.md
+++ b/skills/session-loop/templates/NEXT_SESSION.md
@@ -1,0 +1,101 @@
+<!--
+NEXT_SESSION.md — ephemeral handoff state.
+
+Written by /session-wrap or /session-checkpoint. Consumed by /session-catchup. Overwritten (not appended) every time.
+
+This is NOT a long-lived artifact. Do not link to it from other docs. Do not cite it in commits. If something here matters long-term, it belongs in DECISIONS.md (or the project ledger) or UPDATES.md.
+-->
+
+# Handoff — <YYYY-MM-DD HH:MM TZ>
+
+## Snapshot
+
+| Field | Value |
+| --- | --- |
+| Wrap kind | `wrap` or `checkpoint` |
+| Project root | `<absolute path>` |
+| Branch | `<branch name>` |
+| Git HEAD | `<short sha>` (`<full sha>`) |
+| Ahead of origin | `<N>` commits |
+| Working tree | clean / dirty (see Dirty files below) |
+| Forced wrap? | no / yes — reason: `<reason>` |
+| Agent / model | `<name + version>` |
+
+## What I was doing
+
+<2–4 sentences. The narrative beat. Not a list of every tool call — the *intent*.>
+
+Example: "Migrating auth-ternity from AWS Lambda (me-central-1) to AKS UAE North. Got the Helm chart rendering cleanly, applied to dev cluster, pods are Running but the readiness probe is flapping. Suspect the JWKS cache initialization is racing with the first request."
+
+## Where I stopped
+
+<2–4 sentences on the exact stopping point. What was the last action taken? What is the immediate next action that would resume work?>
+
+## Top 3 candidate entry points
+
+In priority order. Each is a concrete, small action the next session can start with — not a high-level milestone.
+
+1. **<title>** — <one-line action and expected outcome>
+2. **<title>** — <one-line action and expected outcome>
+3. **<title>** — <one-line action and expected outcome>
+
+## Recommended start
+
+`#<N>` because `<one-line reason>`.
+
+## Open threads (carry-forward)
+
+Things that are *not* recoverable by reading the code or ledger. Mid-session intent, ruled-out approaches, ambient constraints expressed by the user.
+
+- <thread>
+- <thread>
+
+## Blockers / unanswered questions
+
+<Anything that requires human input, an external decision, or a stakeholder ping before progress can resume.>
+
+- <blocker>
+
+## Verification commands
+
+Run these at start of next session (via `/session-catchup`) to confirm the world still matches this snapshot. Each command paired with the output observed at wrap time.
+
+```
+$ <command 1>
+<output observed at wrap>
+
+$ <command 2>
+<output observed at wrap>
+```
+
+Minimal recommended set:
+
+```
+$ git rev-parse HEAD
+<sha>
+
+$ git status --porcelain
+<(empty if clean)>
+```
+
+Add domain-specific commands as relevant: `kubectl get pods -n <ns>`, `helm list -n <ns>`, `gh pr view <N> --json state,mergeable`, `az resource list --resource-group <rg> -o table`, `terraform plan -detailed-exitcode`.
+
+## Dirty files (if any)
+
+Only populated when `--force` was used. Otherwise the gate would have refused.
+
+```
+<git status --porcelain output>
+```
+
+## Resume command
+
+```
+/session-catchup
+```
+
+(Or a specialized variant if the next session has a clear non-default start: `/session-catchup --focus <thread>`.)
+
+## Notes for next session
+
+<Free-form. Anything that doesn't fit the slots above but the next session should know. Keep it short — long notes belong in UPDATES.md, not here.>


### PR DESCRIPTION
## Summary

Adds **session-loop**: an umbrella skill plus 7 namespaced slash commands for multi-day agent-assisted projects (Claude Code, Codex). Composes with append-only project ledgers (`DECISIONS.md`, `MIGRATION_LEDGER.md`, `ADR.md` etc.) rather than replacing them.

Built for the seam between sessions — context evaporation, decision re-litigation, silent drift — that existing Claude Code primitives (`/compact`, memory, TaskCreate) don't cover.

## Commands

| Slash form | Purpose |
| --- | --- |
| `/session-wrap` | End-of-session safety gate + handoff write. Refuses dirty stops. Auto-commits its own artifacts only. |
| `/session-catchup` | Start-of-session rehydrate + drift check. Replaces built-in `/resume` (which loads chat transcripts, not project state). |
| `/session-checkpoint` | Mid-session light save. Flags newly-crossed irreversible boundaries. |
| `/session-drift` | Reality-vs-ledger reconcile. Read-only. |
| `/session-decide` | ADR-style decision logger. Append-only, no retro-edit. |
| `/session-open-loops` | Ranked unresolved threads across handoff, narrative, ledger, in-repo TODOs, open PRs. Read-only. |
| `/session-compact-check` | Pre-compaction state persistence. Migrated from `~/.claude/commands/compact-check.md`. |

## Artifact contract

| File | Lifecycle | Owners |
| --- | --- | --- |
| `NEXT_SESSION.md` | Ephemeral; overwritten by wrap/checkpoint | Write: wrap, checkpoint. Read: catchup, open-loops, compact-check. |
| `DECISIONS.md` (or discovered `MIGRATION_LEDGER.md` etc.) | Append-only | Write: decide. Read: catchup, drift, open-loops. |
| `UPDATES.md` | Append-only narrative, newest-on-top | Write: wrap. Read: catchup. |

Ledger auto-discovery composes with existing project conventions (e.g. `tern-infra`'s `MIGRATION_LEDGER.md`) — no migration needed.

## Design principles

- Append-only — supersede, never retro-edit.
- Idempotent — every command safe to rerun.
- Verify, don't trust — handoffs include verification commands re-run on catchup.
- Refuse dirty stops — safety gate before handoff write; `--force <reason>` to override.
- Suggest-only over user work — wrap never auto-fixes, auto-stages, or auto-commits user files. Auto-commits its own artifacts (UPDATES.md, ledger, NEXT_SESSION.md) only when user confirms.
- Slash commands namespaced `/session-*` to avoid clash with bare names other tools commonly claim (`/wrap`, `/drift`, `/decide`).

## Files

```
skills/session-loop/
├── SKILL.md                      umbrella + dispatch + ledger discovery
├── README.md                     install + reference + Beyond engineering mapping
├── WALKTHROUGH.md                day-1/day-2/day-3 walkthrough w/ sample outputs
├── LICENSE                       MIT
├── install.sh                    symlinks skill + 7 command stubs
├── sub/                          7 sub-flow procedures (wrap, catchup, etc.)
├── commands/                     7 slash command stubs (session-wrap.md etc.)
└── templates/
    ├── NEXT_SESSION.md           ephemeral handoff template
    └── DECISION.md               ADR template
```

Plus 1-line entry added to `scripts/publish-skill.sh` MIRROR_REMOTES for publishing to the new `github.com/akshayrao14/session-loop` mirror.

## Not in scope for this PR

- Profile system for non-engineering domains (PM, research, writing). Core works generically today; auto-probes are engineering-flavored. Deferred until adoption signal. README's "Beyond engineering" section explains workaround + future plan.
- README.md (root) updates. The README rewrite + skills table row for session-loop are on the `dotfiles-repohue` branch already pending merge to `main`; not duplicated here.
- Publishing to the mirror repo. `github.com/akshayrao14/session-loop` exists (empty); `bash scripts/publish-skill.sh session-loop v0.1.0` does the subtree push when ready.

## Test plan

- [ ] Local install via `bash skills/session-loop/install.sh` succeeds (symlinks skill + 7 commands)
- [ ] Restart Claude Code; `/session-` autocompletes 7 commands; skill listed in `/skills`
- [ ] In a multi-day project (`tern-infra`), `/session-wrap` discovers existing `MIGRATION_LEDGER.md` (not `DECISIONS.md` default)
- [ ] `/session-wrap` refuses on dirty `.env` (sensitive-file gate works)
- [ ] `/session-wrap --force "intentional dirty state"` proceeds, logs forced reason in `UPDATES.md`
- [ ] `/session-catchup` re-runs verification commands and surfaces drift when git HEAD changes
- [ ] `/session-decide` appends `AD-NNN` correctly numbered after last existing AD
- [ ] `/session-open-loops` ranks BLOCKER > PR REVIEW > AD FOLLOW-UP > etc.
- [ ] `/session-drift` skips probes whose CLI is missing (e.g. `terraform` not installed) without failing
- [ ] `/session-checkpoint` flags newly-crossed irreversible boundary (e.g. `helm install` since last save)
- [ ] `/session-compact-check` writes only to "Open threads" + "Notes" sections of `NEXT_SESSION.md`, leaves snapshot intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)